### PR TITLE
Add libqtcore4 dependency for Client in linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Download a copy of the [OpenBench Client File](https://github.com/AndyGrant/Open
 
 ``sudo apt-get install g++ or yum install g++``
 
+``sudo apt-get install libqtcore4 or yum install libqtcore4``
+
 Download a copy of the [OpenBench Client File](https://github.com/AndyGrant/OpenBench/blob/master/Client/OpenBench.py)
 
 # Running The Client


### PR DESCRIPTION
Getting the Linux Client cutechess to run required an extra dependency that is not documented:

sudo apt-get install libqtcore4

Would be good idea to add this to the README for people who might not know what they're doing or have older machines.