### PR TITLE
Local time

### DIFF
--- a/Templates/OpenBench/events.html
+++ b/Templates/OpenBench/events.html
@@ -14,7 +14,11 @@
 
         {% for event in events %}
             <tr>
-                <td>{{event.creation|date:'Y-m-d H:i:s'}}</td>
+                <td id="date-obj-{{forloop.counter}}">{{event.creation|date:'Y-m-d H:i:s'}}</td>
+                <script>
+                    var dateobj = document.getElementById("date-obj-{{forloop.counter}}")
+                    dateobj.innerHTML = new Date(dateobj.innerHTML + "+00:00").toLocaleString();
+                </script>
                 <td>{{event.author}}</td>
                 <td><a href="/test/{{event.test.id}}">{{event.test.dev.name}}</a></td>
                 <td>{{event.test.timecontrol}}</td>

--- a/Templates/OpenBench/machines.html
+++ b/Templates/OpenBench/machines.html
@@ -21,7 +21,11 @@
                 <td class="numeric">{{machine.id}}</td>
                 <td>{{machine.owner}}</td>
                 <td>{{machine.osname}}</td>
-                <td>{{machine.updated|date:'Y-m-d H:i'}}</td>
+                <td id="date-obj-{{forloop.counter}}">{{machine.updated|date:'Y-m-d H:i'}}</td>
+                <script>
+                    var dateobj = document.getElementById("date-obj-{{forloop.counter}}")
+                    dateobj.innerHTML = new Date(dateobj.innerHTML + "+00:00").toLocaleString();
+                </script>
                 <td> <a href="/test/{{machine.workload.id}}">{{machine.workload.dev.name}}</a></td>
                 <td class="numeric">{{machine.threads}}</td>
                 <td class="numeric">{{machine.mnps|twoDigitPrecision}}</td>


### PR DESCRIPTION
Show time stamps relative to local time in /events/ and /machines/. Code might be horrible as I don't know javascript at all. The datetime format changes a bit from current, but toLocaleString() has a bunch of options to control formatting so this can probably be fixed if it's a problem.

https://i.imgur.com/wtlQ9Hr.png