### PR TITLE
Implement net files support for NNUE engines

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -240,18 +240,15 @@ def getEngine(data, engine):
     # Cleanup the zipfile directory
     shutil.rmtree('tmp')
 
-def getNetwork(data, net):
-    targetnet = str(data['test'][net])
+def getNetworkWeights(network):
 
-    if targetnet:
-        localnet = pathjoin('Engines', os.path.basename(targetnet)).rstrip('/')
-        # Check if a given network file is present in Engines directory
-        if os.path.isfile(localnet):
-            return os.path.basename(targetnet)
-        # Download network file
-        getFile(targetnet, localnet)
-        return os.path.basename(targetnet)
-    
+    if network:
+        fname = pathjoin('Engines', os.path.basename(network)).rstrip('/')
+        if not os.path.isfile(fname): getFile(network, fname)
+        return os.path.basename(network)
+
+    return None
+
 def getCutechessCommand(arguments, data, nps):
 
     # Parse options for Dev
@@ -269,8 +266,8 @@ def getCutechessCommand(arguments, data, nps):
     baseCommand = addExtension(data['test']['base']['sha'])
 
     # Download network file(s) if configured
-    devnetwork  = getNetwork(data, 'devnetwork')
-    basenetwork = getNetwork(data, 'basenetwork')
+    devnetwork  = getNetworkWeights(data['test']['dev']['network'])
+    basenetwork = getNetworkWeights(data['test']['base']['network'])
 
     # Scale the time control for this machine's speed
     timecontrol = computeAdjustedTimecontrol(arguments, data, nps)
@@ -299,7 +296,7 @@ def getCutechessCommand(arguments, data, nps):
         '{0}-{1}'.format(data['test']['engine'], data['test']['dev']['name'])
     )
 
-    # In case devnetwork is specified append EvalFile option
+    # Add evaluation weights for the Dev engine if specified
     if devnetwork:
         devflags = devflags + " option.EvalFile=" + devnetwork
 
@@ -309,10 +306,10 @@ def getCutechessCommand(arguments, data, nps):
         '{0}-{1}'.format(data['test']['engine'], data['test']['base']['name'])
     )
 
-    # In case basenetwork is specified append EvalFile option
+    # Add evaluation weights for the Base engine if specified
     if basenetwork:
         baseflags = baseflags + " option.EvalFile=" + basenetwork
-        
+
     # Options for opening selection
     bookflags = '-openings file=Books/{0} format={1} order=random plies=16'.format(
         data['test']['book']['name'], data['test']['book']['name'].split('.')[-1]

--- a/OpenBench/models.py
+++ b/OpenBench/models.py
@@ -116,8 +116,8 @@ class Test(Model):
 
     creation    = DateTimeField(auto_now_add=True)
     updated     = DateTimeField(auto_now=True)
-    devnet      = CharField(max_length=256)
-    basenet     = CharField(max_length=256)
+    devnetwork  = CharField(max_length=256)
+    basenetwork = CharField(max_length=256)
 
     def __str__(self):
         return '{0} vs {1} @ {2}'.format(self.dev.name, self.base.name, self.timecontrol)

--- a/OpenBench/models.py
+++ b/OpenBench/models.py
@@ -87,6 +87,9 @@ class Test(Model):
     devoptions  = CharField(max_length=256)
     baseoptions = CharField(max_length=256)
 
+    devnetwork  = CharField(max_length=256)
+    basenetwork = CharField(max_length=256)
+
     bookname    = CharField(max_length=32)
     timecontrol = CharField(max_length=16)
 
@@ -116,8 +119,6 @@ class Test(Model):
 
     creation    = DateTimeField(auto_now_add=True)
     updated     = DateTimeField(auto_now=True)
-    devnetwork  = CharField(max_length=256)
-    basenetwork = CharField(max_length=256)
 
     def __str__(self):
         return '{0} vs {1} @ {2}'.format(self.dev.name, self.base.name, self.timecontrol)

--- a/OpenBench/models.py
+++ b/OpenBench/models.py
@@ -116,6 +116,8 @@ class Test(Model):
 
     creation    = DateTimeField(auto_now_add=True)
     updated     = DateTimeField(auto_now=True)
+    devnet      = CharField(max_length=256)
+    basenet     = CharField(max_length=256)
 
     def __str__(self):
         return '{0} vs {1} @ {2}'.format(self.dev.name, self.base.name, self.timecontrol)

--- a/OpenBench/utils.py
+++ b/OpenBench/utils.py
@@ -203,6 +203,10 @@ def verifyNewTest(request):
         if request.POST[field] not in OpenBench.config.OPENBENCH_CONFIG[parent].keys():
             errors.append('{0} was not found in the configuration'.format(fieldName))
 
+    def verifyGithubLink(field, fieldName):
+        if request.POST[field] and not request.POST[field].startswith('https://github.com/'):
+            errors.append('{0} must be located on a Github URL'.format(fieldName))
+
     verifications = [
         (verifyInteger, 'priority', 'Priority'),
         (verifyInteger, 'throughput', 'Throughput'),
@@ -221,6 +225,8 @@ def verifyNewTest(request):
         (verifyOptions, 'baseoptions', 'Hash', 'Base Options'),
         (verifyConfiguration, 'enginename', 'Engine', 'engines'),
         (verifyConfiguration, 'bookname', 'Book', 'books'),
+        (verifyGithubLink, 'devnetwork', 'Dev Network'),
+        (verifyGithubLink, 'basenetwork', 'Base Network'),
     ]
 
     for verification in verifications:
@@ -245,6 +251,8 @@ def createNewTest(request):
     test.source      = request.POST['source']
     test.devoptions  = request.POST['devoptions']
     test.baseoptions = request.POST['baseoptions']
+    test.devnetwork  = request.POST['devnetwork']
+    test.basenetwork = request.POST['basenetwork']
     test.bookname    = request.POST['bookname']
     test.timecontrol = request.POST['timecontrol']
     test.priority    = int(request.POST['priority'])
@@ -257,8 +265,6 @@ def createNewTest(request):
     test.upperllr    = math.log((1.0 - test.beta) / test.alpha)
     test.dev         = getEngine(*devinfo, protocol)
     test.base        = getEngine(*baseinfo, protocol)
-    test.devnetwork  = request.POST['devnetwork']
-    test.basenetwork = request.POST['basenetwork']
     test.save()
 
     profile = Profile.objects.get(user=request.user)
@@ -383,6 +389,7 @@ def workloadDictionary(test, result, machine):
                 'source'    : test.dev.source,  'protocol'  : test.dev.protocol,
                 'sha'       : test.dev.sha,     'bench'     : test.dev.bench,
                 'options'   : test.devoptions,
+                'network'   : test.devnetwork,
             },
 
             'base' : {
@@ -390,9 +397,8 @@ def workloadDictionary(test, result, machine):
                 'source'    : test.base.source, 'protocol'  : test.base.protocol,
                 'sha'       : test.base.sha,    'bench'     : test.base.bench,
                 'options'   : test.baseoptions,
+                'network'   : test.basenetwork,
             },
-            'devnetwork'    : test.devnetwork,
-            'basenetwork'   : test.basenetwork,
         },
     }
 

--- a/OpenBench/utils.py
+++ b/OpenBench/utils.py
@@ -257,8 +257,8 @@ def createNewTest(request):
     test.upperllr    = math.log((1.0 - test.beta) / test.alpha)
     test.dev         = getEngine(*devinfo, protocol)
     test.base        = getEngine(*baseinfo, protocol)
-    test.devnet      = request.POST['devnet']
-    test.basenet     = request.POST['basenet']
+    test.devnetwork  = request.POST['devnetwork']
+    test.basenetwork = request.POST['basenetwork']
     test.save()
 
     profile = Profile.objects.get(user=request.user)
@@ -391,8 +391,8 @@ def workloadDictionary(test, result, machine):
                 'sha'       : test.base.sha,    'bench'     : test.base.bench,
                 'options'   : test.baseoptions,
             },
-            'devnet'        : test.devnet,
-            'basenet'       : test.basenet,
+            'devnetwork'    : test.devnetwork,
+            'basenetwork'   : test.basenetwork,
         },
     }
 

--- a/OpenBench/utils.py
+++ b/OpenBench/utils.py
@@ -257,6 +257,8 @@ def createNewTest(request):
     test.upperllr    = math.log((1.0 - test.beta) / test.alpha)
     test.dev         = getEngine(*devinfo, protocol)
     test.base        = getEngine(*baseinfo, protocol)
+    test.devnet      = request.POST['devnet']
+    test.basenet     = request.POST['basenet']
     test.save()
 
     profile = Profile.objects.get(user=request.user)
@@ -376,7 +378,6 @@ def workloadDictionary(test, result, machine):
             'book'          : OPENBENCH_CONFIG['books'][test.bookname],
             'timecontrol'   : test.timecontrol,
             'engine'        : test.engine,
-
             'dev' : {
                 'id'        : test.dev.id,      'name'      : test.dev.name,
                 'source'    : test.dev.source,  'protocol'  : test.dev.protocol,
@@ -390,6 +391,8 @@ def workloadDictionary(test, result, machine):
                 'sha'       : test.base.sha,    'bench'     : test.base.bench,
                 'options'   : test.baseoptions,
             },
+            'devnet'        : test.devnet,
+            'basenet'       : test.basenet,
         },
     }
 

--- a/Templates/OpenBench/newTest.html
+++ b/Templates/OpenBench/newTest.html
@@ -62,14 +62,14 @@
             <h3> Dev Settings </h3>
             <label> Bench </label> <input name="devbench"><br>
             <label> Branch </label> <input name="devbranch" autofocus><br>
-            <label> Net </label> <input name="devnet"><br>
             <label> Options </label> <input id="devoptions" name="devoptions"><br>
+            <label> Network </label> <input name="devnetwork"><br>
 
             <h3> Base Settings </h3>
             <label> Bench </label> <input name="basebench"><br>
             <label> Branch </label> <input value="master" name="basebranch"><br>
-            <label> Net </label> <input name="basenet"><br>
             <label> Options </label> <input id="baseoptions" name="baseoptions"><br>
+            <label> Network </label> <input name="basenetwork"><br>
 
         </div>
 

--- a/Templates/OpenBench/newTest.html
+++ b/Templates/OpenBench/newTest.html
@@ -62,11 +62,13 @@
             <h3> Dev Settings </h3>
             <label> Bench </label> <input name="devbench"><br>
             <label> Branch </label> <input name="devbranch" autofocus><br>
+            <label> Net </label> <input name="devnet"><br>
             <label> Options </label> <input id="devoptions" name="devoptions"><br>
 
             <h3> Base Settings </h3>
             <label> Bench </label> <input name="basebench"><br>
             <label> Branch </label> <input value="master" name="basebranch"><br>
+            <label> Net </label> <input name="basenet"><br>
             <label> Options </label> <input id="baseoptions" name="baseoptions"><br>
 
         </div>

--- a/Templates/OpenBench/test.html
+++ b/Templates/OpenBench/test.html
@@ -14,9 +14,11 @@
             <tr><th>Dev Branch</th><td>{{test.dev.name|prettyName}}</td></tr>
             <tr><th>Dev Bench</th><td>{{test.dev.bench}}</td></tr>
             <tr><th>Dev Options</th><td>{{test.devoptions}}</td></tr>
+            <tr><th>Dev Net</th><td>{{test.devnet}}</td></tr>
             <tr><th>Dev Sha</th><td>{{test.dev.sha}}</td></tr>
             <tr><th>Base Branch</th><td>{{test.base.name|prettyName}}</td></tr>
             <tr><th>Base Bench</th><td>{{test.base.bench}}</td></tr>
+            <tr><th>Base Net</th><td>{{test.basenet}}</td></tr>
             <tr><th>Base Options</th><td>{{test.baseoptions}}</td></tr>
             <tr><th>Base Sha</th><td>{{test.base.sha}}</td></tr>
             <tr><th>Source Repo</th><td>{{test.source}}</td></tr>

--- a/Templates/OpenBench/test.html
+++ b/Templates/OpenBench/test.html
@@ -14,13 +14,17 @@
             <tr><th>Dev Branch</th><td>{{test.dev.name|prettyName}}</td></tr>
             <tr><th>Dev Bench</th><td>{{test.dev.bench}}</td></tr>
             <tr><th>Dev Options</th><td>{{test.devoptions}}</td></tr>
-            <tr><th>Dev Net</th><td>{{test.devnet}}</td></tr>
             <tr><th>Dev Sha</th><td>{{test.dev.sha}}</td></tr>
+            {% if test.devnetwork %}
+            <tr><th>Dev Network</th><td>{{test.devnetwork}}</td></tr>
+            {% endif %}
             <tr><th>Base Branch</th><td>{{test.base.name|prettyName}}</td></tr>
             <tr><th>Base Bench</th><td>{{test.base.bench}}</td></tr>
-            <tr><th>Base Net</th><td>{{test.basenet}}</td></tr>
             <tr><th>Base Options</th><td>{{test.baseoptions}}</td></tr>
             <tr><th>Base Sha</th><td>{{test.base.sha}}</td></tr>
+            {% if test.basenetwork %}
+            <tr><th>Base Network</th><td>{{test.basenetwork}}</td></tr>
+            {% endif %}
             <tr><th>Source Repo</th><td>{{test.source}}</td></tr>
             <tr><th>Opening Book</th><td>{{test.bookname}}</td></tr>
             <tr><th>Time Control</th><td>{{test.timecontrol}}s</td></tr>


### PR DESCRIPTION
This PR implements support for network files (for NNUE based engines) in OpenBench:

- Test model object is modified and it contains two new fields: devnetwork and basenetwork (256 characters max)
- Client script is modified to download devnetwork and basenetwork into 'Engines' directory and pass as option.EvalFile to an engine
- In case Engines folder already contains eval file the download is skipped to preserve bandwidth
- UI is modified to allow net URLs to be passed during creation of a test
- UI is modified to view net URLs to per each test

This is how UI looks like now

Creation of new test:

![image](https://user-images.githubusercontent.com/337059/92049475-e155fc80-ed8a-11ea-9f7e-81c13fceb70f.png)

Seeing existing test without devnetwork and basenetwork parameters:

![image](https://user-images.githubusercontent.com/337059/92049504-f29f0900-ed8a-11ea-8935-ad56c3edee56.png)

Seeing existing test with devnetwork and basenetwork parameters:

![image](https://user-images.githubusercontent.com/337059/92049514-f7fc5380-ed8a-11ea-9611-12067bcaf479.png)

This PR is tested on my local open bench instance http://shcherbyna.com:8000/index/ using Windows 10 and CentOS/Ubuntu/Debian clients.

Important: the changes on back end are not going to break old clients because they will ignore basenetwork and devnetwork fields and will continue working.