### PR TITLE
Use network file during bench for proper time scaling

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -362,16 +362,12 @@ def computeSingleThreadedBenchmark(engine, outqueue, network):
 
     try:
 
-        # Launch the engine and run a benchmark
-        pathway = addExtension(os.path.join('Engines', engine).rstrip('/'))
-        cmdline = './{0} bench'
-        if network:
-            cmdline = cmdline + " option.EvalFile=" + os.path.join('Engines', network).rstrip('/')
-        stdout, stderr = subprocess.Popen(
-            cmdline.format(pathway).split(),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        ).communicate()
+        # Assume .exe extensions on Windows; Pass any Network files with the benchmark
+        cmdline = './{0} bench'.format(addExtension(os.path.join('Engines', engine).rstrip('/')))
+        if network: cmdline += " option.EvalFile=" + os.path.join('Engines', network).rstrip('/')
+
+        # Launch the engine and run it's benchmark
+        stdout, stderr = subprocess.Popen(cmdline.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
 
         # Parse output streams for the benchmark data
         bench, speed = parseStreamOutput(stdout)


### PR DESCRIPTION
This PR implements proper time scaling for NNUE based engines in OpenBench by using network file during 'bench' command:

- Before performing 'bench' command the OB client downloads the appropriate network file for dev/base engine
- Network file is passed to command line only if configured, so no need to update existing engines that do not support option.EvalFile in the command line
- The exact format of the command line becomes: _engine bench option.EvalFile=path_to_network_file_

Testing scenarios:

1. Passing network file to the test (in this case 'option.EvalFile' is added to bench command line)
2. Not passing network file to the test (in this case original command line is used that only does 'bench')