### PR TITLE
Enforce HTTPS urls for network files

### DIFF
--- a/OpenBench/utils.py
+++ b/OpenBench/utils.py
@@ -203,9 +203,9 @@ def verifyNewTest(request):
         if request.POST[field] not in OpenBench.config.OPENBENCH_CONFIG[parent].keys():
             errors.append('{0} was not found in the configuration'.format(fieldName))
 
-    def verifyGithubLink(field, fieldName):
-        if request.POST[field] and not request.POST[field].startswith('https://github.com/'):
-            errors.append('{0} must be located on a Github URL'.format(fieldName))
+    def verifySecureLink(field, fieldName):
+        if request.POST[field] and not request.POST[field].startswith('https://'):
+            errors.append('{0} must be located on a HTTPS URL'.format(fieldName))
 
     verifications = [
         (verifyInteger, 'priority', 'Priority'),
@@ -225,8 +225,8 @@ def verifyNewTest(request):
         (verifyOptions, 'baseoptions', 'Hash', 'Base Options'),
         (verifyConfiguration, 'enginename', 'Engine', 'engines'),
         (verifyConfiguration, 'bookname', 'Book', 'books'),
-        (verifyGithubLink, 'devnetwork', 'Dev Network'),
-        (verifyGithubLink, 'basenetwork', 'Base Network'),
+        (verifySecureLink, 'devnetwork', 'Dev Network'),
+        (verifySecureLink, 'basenetwork', 'Base Network'),
     ]
 
     for verification in verifications:


### PR DESCRIPTION
This PR implements enforcement of HTTPS to be used for network files.

Testing scenarios:

1. Passing network file on a HTTP link results in error

![image](https://user-images.githubusercontent.com/337059/92274233-26923f80-eeed-11ea-8b5a-ae756a31d2c9.png)

2. Passing network file on a HTTPS link works well

3. Empy network file links are still allowed