### PR TITLE
Adaptive workload size

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -273,9 +273,9 @@ def getCutechessCommand(arguments, data, nps, devnetwork, basenetwork):
     # Find max concurrency for the given testing conditions
     concurrency = int(math.floor(int(arguments.threads) / max(devthreads, basethreads)))
 
-    # Compute needed games per thread to reach the workload time
+    # Compute needed games per concurrency to reach the workload time
     # Round it to the next integer to avoid potential "zero games" workloads with very long TCs
-    gamesPerThread = int(math.ceil(TIME_PER_WORKLOAD / avgGameDuration))
+    gamesPerConcurrency = int(math.ceil(TIME_PER_WORKLOAD / avgGameDuration))
 
     # Check for an FRC/Chess960 opening book
     if "FRC" in data['test']['book']['name'].upper(): variant = 'fischerandom'
@@ -287,7 +287,7 @@ def getCutechessCommand(arguments, data, nps, devnetwork, basenetwork):
         int(time.time()), 'movecount=3 score=400', 'movenumber=40 movecount=8 score=10'
     )
 
-    totalGames = concurrency * gamesPerThread
+    totalGames = concurrency * gamesPerConcurrency
 
     # Options about tournament conditions. Take care of using an even number of games
     # to ensure each opening is played twice

--- a/Client/Client.py
+++ b/Client/Client.py
@@ -287,9 +287,12 @@ def getCutechessCommand(arguments, data, nps, devnetwork, basenetwork):
         int(time.time()), 'movecount=3 score=400', 'movenumber=40 movecount=8 score=10'
     )
 
-    # Options about tournament conditions
+    totalGames = concurrency * gamesPerThread
+
+    # Options about tournament conditions. Take care of using an even number of games
+    # to ensure each opening is played twice
     setupflags = '-variant {0} -concurrency {1} -games {2}'.format(
-        variant, concurrency, concurrency * gamesPerThread
+        variant, concurrency, totalGames + (totalGames % 2)
     )
 
     # Options for the Dev Engine


### PR DESCRIPTION
For now OpenBench Client always uses the same number of games per workload (defined by GAMES_PER_CONCURRENCY variable), independently of the time control used.
This leads to very long waiting times for STC tests when LTC ones are running at the same time.

This PR fixes this issue by making the number of games scale with the length of the selected time control, replacing GAMES_PER_CONCURRENCY by TIME_PER_WORKLOAD (defaulting to 10 minutes). It also has the advantage to make slow workers switch workloads more often.