### PR TITLE
Make the Client use multiprocessed 'make' commands for engines that support it

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -36,16 +36,16 @@ SAVE_PGN_FILES        = False # Auto-save PGN output for engine pairings
 AUTO_DELETE_ENGINES   = True  # Delete Engines that are over 24hrs old
 
 CUSTOM_SETTINGS = {
-    'Ethereal'  : { 'args' : [], 'mp_build': False }, # Configuration for Ethereal
-    'Laser'     : { 'args' : [], 'mp_build': True  }, # Configuration for Laser
-    'Weiss'     : { 'args' : [], 'mp_build': False }, # Configuration for Weiss
-    'Demolito'  : { 'args' : [], 'mp_build': False }, # Configuration for Demolito
-    'Rubichess' : { 'args' : [], 'mp_build': False }, # Configuration for RubiChess
-    'FabChess'  : { 'args' : [], 'mp_build': False }, # Configuration for FabChess
-    'Igel'      : { 'args' : [], 'mp_build': False }, # Configuration for Igel
-    'Winter'    : { 'args' : [], 'mp_build': True  }, # Configuration for Winter
-    'Halogen'   : { 'args' : [], 'mp_build': False }, # Configuration for Halogen
-    'Stash'     : { 'args' : [], 'mp_build': True  }, # Configuration for Stash
+    'Ethereal'  : { 'args' : [] }, # Configuration for Ethereal
+    'Laser'     : { 'args' : [] }, # Configuration for Laser
+    'Weiss'     : { 'args' : [] }, # Configuration for Weiss
+    'Demolito'  : { 'args' : [] }, # Configuration for Demolito
+    'Rubichess' : { 'args' : [] }, # Configuration for RubiChess
+    'FabChess'  : { 'args' : [] }, # Configuration for FabChess
+    'Igel'      : { 'args' : [] }, # Configuration for Igel
+    'Winter'    : { 'args' : [] }, # Configuration for Winter
+    'Halogen'   : { 'args' : [] }, # Configuration for Halogen
+    'Stash'     : { 'args' : [] }, # Configuration for Stash
 };
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -241,9 +241,8 @@ def getEngine(arguments, data, engine, network):
     if data['test']['engine'] in CUSTOM_SETTINGS:
         command.extend(CUSTOM_SETTINGS[data['test']['engine']]['args'])
 
-        # Use multiprocessed build if the engine supports it
-        if CUSTOM_SETTINGS[data['test']['engine']]['mp_build']:
-            command.append('-j' + arguments.threads)
+    # Allow for multiprocessed build up to the number of requested threads
+    command.append('-j' + arguments.threads)
 
     # Build the engine. If something goes wrong with the
     # compilation process, we will figure this out later on

--- a/Client/Client.py
+++ b/Client/Client.py
@@ -36,16 +36,16 @@ SAVE_PGN_FILES        = False # Auto-save PGN output for engine pairings
 AUTO_DELETE_ENGINES   = True  # Delete Engines that are over 24hrs old
 
 CUSTOM_SETTINGS = {
-    'Ethereal'  : { 'args' : [] }, # Configuration for Ethereal
-    'Laser'     : { 'args' : [] }, # Configuration for Laser
-    'Weiss'     : { 'args' : [] }, # Configuration for Weiss
-    'Demolito'  : { 'args' : [] }, # Configuration for Demolito
-    'Rubichess' : { 'args' : [] }, # Configuration for RubiChess
-    'FabChess'  : { 'args' : [] }, # Configuration for FabChess
-    'Igel'      : { 'args' : [] }, # Configuration for Igel
-    'Winter'    : { 'args' : [] }, # Configuration for Winter
-    'Halogen'   : { 'args' : [] }, # Configuration for Halogen
-    'Stash'     : { 'args' : [] }, # Configuration for Stash
+    'Ethereal'  : { 'args' : [], 'mp_build': False }, # Configuration for Ethereal
+    'Laser'     : { 'args' : [], 'mp_build': True  }, # Configuration for Laser
+    'Weiss'     : { 'args' : [], 'mp_build': False }, # Configuration for Weiss
+    'Demolito'  : { 'args' : [], 'mp_build': False }, # Configuration for Demolito
+    'Rubichess' : { 'args' : [], 'mp_build': False }, # Configuration for RubiChess
+    'FabChess'  : { 'args' : [], 'mp_build': False }, # Configuration for FabChess
+    'Igel'      : { 'args' : [], 'mp_build': False }, # Configuration for Igel
+    'Winter'    : { 'args' : [], 'mp_build': True  }, # Configuration for Winter
+    'Halogen'   : { 'args' : [], 'mp_build': False }, # Configuration for Halogen
+    'Stash'     : { 'args' : [], 'mp_build': True  }, # Configuration for Stash
 };
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -211,7 +211,7 @@ def getMachineID():
     print('[NOTE] Machine Is Unregistered')
     return 'None'
 
-def getEngine(data, engine, network):
+def getEngine(arguments, data, engine, network):
 
     print('Engine  {0}'.format(data['test']['engine']))
     print('Branch  {0}'.format(engine['name']))
@@ -240,6 +240,10 @@ def getEngine(data, engine, network):
     # Add any other custom compilation options if we have them
     if data['test']['engine'] in CUSTOM_SETTINGS:
         command.extend(CUSTOM_SETTINGS[data['test']['engine']]['args'])
+
+        # Use multiprocessed build if the engine supports it
+        if CUSTOM_SETTINGS[data['test']['engine']]['mp_build']:
+            command.append('-j' + arguments.threads)
 
     # Build the engine. If something goes wrong with the
     # compilation process, we will figure this out later on
@@ -494,7 +498,7 @@ def verifyEngine(arguments, data, engine, network):
     # Download the engine if we do not already have it
     name = savedEngineName(engine['sha'], network)
     pathway = addExtension(pathjoin('Engines', name).rstrip('/'))
-    if not os.path.isfile(pathway): getEngine(data, engine, network)
+    if not os.path.isfile(pathway): getEngine(arguments, data, engine, network)
 
     # Run a group of benchmarks in parallel in order to better scale NPS
     # values for this worker. We obtain a bench and average NPS value


### PR DESCRIPTION
This PR just adds a new field to the CUSTOM_SETTINGS variable indicating if the engine supports multiprocessed build, and uses the given '--threads' argument when running the Client as the number of threads used for building (with the flag -j). If the engine doesn't support it, no additional flag is given to the 'make' command.