### PR TITLE
Add gcc compiler requirement for Zahak

### DIFF
--- a/OpenBench/config.py
+++ b/OpenBench/config.py
@@ -409,7 +409,7 @@ OPENBENCH_CONFIG = {
 
             'build'     : {
                 'path'      : '',
-                'compilers' : ['go'],
+                'compilers' : ['go', 'gcc'],
                 'cpuflags'  : ['AVX', 'POPCNT'],
             },
 


### PR DESCRIPTION
After adding syzygy support, Zahak needs GCC as well as Go compilers