### PR TITLE
Use credentials from environment when not supplied in command line

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -841,14 +841,22 @@ def run_and_parse_cutechess(arguments, workload, concurrency, update_interval, c
 if __name__ == '__main__':
 
     p = argparse.ArgumentParser()
-    p.add_argument('-U', '--username', help='Username' , required=True)
-    p.add_argument('-P', '--password', help='Password' , required=True)
+    p.add_argument('-U', '--username', help='Username. May also be passed as OPENBENCH_USERNAME environment variable.',
+                   required=('OPENBENCH_USERNAME' not in os.environ))
+    p.add_argument('-P', '--password', help='Password. May also be passed as OPENBENCH_PASSWORD environment variable.',
+                   required=('OPENBENCH_PASSWORD' not in os.environ))
     p.add_argument('-S', '--server'  , help='Webserver', required=True)
     p.add_argument('-T', '--threads' , help='Threads'  , required=True)
     p.add_argument('--syzygy', help='Syzygy WDL'  , required=False)
     p.add_argument('--fleet' , help='Fleet Mode'  , action='store_true')
     p.add_argument('--proxy' , help='Github Proxy', action='store_true')
     arguments = p.parse_args()
+
+    if arguments.username is None:
+        arguments.username = os.environ['OPENBENCH_USERNAME']
+
+    if arguments.password is None:
+        arguments.password = os.environ['OPENBENCH_PASSWORD']
 
     if arguments.syzygy is not None:
         SYZYGY_WDL_PATH = arguments.syzygy


### PR DESCRIPTION
Fall back to OPENBENCH_USERNAME and OPENBENCH_PASSWORD environment
variables when username/password are not passed as command line
arguments. Passing credentials in command line is problematic in
multiuser machines, as full command lines may be visible in process
listings.

***

**The background for this:** I'm setting up a Docker container for OpenBench client + compilers etc. This is mainly for myself, but I'm probably going to publish it in Docker hub. In case someone wants to run the Docker container in cloud or similar, I'd like to avoid revealing the username/password in process listings (e.g., ps -ef / htop / etc).

Also, I don't claim to be a fluent Python dev. Feel free to point out how this should have been done differently :)