### PR TITLE
reduce igel testing bounds

### DIFF
--- a/OpenBench/config.py
+++ b/OpenBench/config.py
@@ -233,7 +233,7 @@ OPENBENCH_CONFIG = {
             'nps'    : 850000,
             'base'   : 'master',
             'book'   : 'Pohl.epd',
-            'bounds' : '[0.00, 5.00]',
+            'bounds' : '[0.00, 3.00]',
             'source' : 'https://github.com/vshcherbyna/igel',
 
             'build' : {


### PR DESCRIPTION
This change reduces Igel default testing bounds to [0.00, 3.00].