### PR TITLE
Delete machine.txt if error "Bad Machine Id" is thrown

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -531,6 +531,8 @@ def server_configure_worker(arguments):
     # The 'error' header is included if there was an issue
     if 'error' in response:
         print('[Error] %s\n' % (response['error']))
+        if (response['error'].lower() == "bad machine id"):
+            os.remove('./machine.txt')
         sys.exit()
 
     # Save the machine id, to avoid re-registering every time


### PR DESCRIPTION
In the function server_configure_worker(), if the error appears in the response is "Bad Machine Id" then delete machine.txt before exiting.