### PR TITLE
Collection of massive breaking changes

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -317,6 +317,10 @@ class ServerReporter(object):
 
 class Cutechess(object):
 
+    ## Handles building the very long string of arguments that need to be passed
+    ## to cutechess in order to launch a set of games. Operates on the Configuration,
+    ## and a small number of secondary arguments that are not housed in the Configuration
+
     @staticmethod
     def basic_settings(config, socket):
 

--- a/Engines/4ku.json
+++ b/Engines/4ku.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "",
         "compilers" : ["g++"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Berserk.json
+++ b/Engines/Berserk.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["gcc"],
-        "cpuflags"  : ["AVX2", "FMA", "POPCNT"]
+        "cpuflags"  : ["AVX2", "FMA", "POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Bit-Genie.json
+++ b/Engines/Bit-Genie.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["g++"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/BlackMarlin.json
+++ b/Engines/BlackMarlin.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "",
         "compilers" : ["cargo>=1.57.0"],
-        "cpuflags"  : [ "AVX2", "FMA", "POPCNT"]
+        "cpuflags"  : ["AVX2", "FMA", "POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Demolito.json
+++ b/Engines/Demolito.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["clang", "gcc"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Drofa.json
+++ b/Engines/Drofa.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "",
         "compilers" : ["g++"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Ethereal.json
+++ b/Engines/Ethereal.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["clang", "gcc"],
-        "cpuflags"  : ["AVX2", "FMA", "POPCNT"]
+        "cpuflags"  : ["AVX2", "FMA", "POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/FabChess.json
+++ b/Engines/FabChess.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "",
         "compilers" : ["cargo>=1.41.0"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Halogen.json
+++ b/Engines/Halogen.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["g++"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Igel.json
+++ b/Engines/Igel.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["g++"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Koivisto.json
+++ b/Engines/Koivisto.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src_files",
         "compilers" : ["g++"],
-        "cpuflags"  : ["AVX2", "FMA", "POPCNT"]
+        "cpuflags"  : ["AVX2", "FMA", "POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Laser.json
+++ b/Engines/Laser.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["g++"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/RubiChess.json
+++ b/Engines/RubiChess.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["g++"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Seer.json
+++ b/Engines/Seer.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "build",
         "compilers" : ["g++>=9.0.0"],
-        "cpuflags"  : ["AVX2", "FMA", "POPCNT"]
+        "cpuflags"  : ["AVX2", "FMA", "POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Stash.json
+++ b/Engines/Stash.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["gcc", "clang"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Weiss.json
+++ b/Engines/Weiss.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["gcc"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Winter.json
+++ b/Engines/Winter.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "",
         "compilers" : ["clang++", "g++"],
-        "cpuflags"  : ["POPCNT"]
+        "cpuflags"  : ["POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/Engines/Zahak.json
+++ b/Engines/Zahak.json
@@ -12,7 +12,8 @@
     "build" : {
         "path"      : "",
         "compilers" : ["go"],
-        "cpuflags"  : ["AVX", "POPCNT"]
+        "cpuflags"  : ["AVX", "POPCNT"],
+        "systems"   : ["Windows", "Linux"]
     },
 
     "testmodes" : {

--- a/OpenBench/config.py
+++ b/OpenBench/config.py
@@ -38,11 +38,11 @@ REQUIRE_MANUAL_REGISTRATION = False # Disable the public facing registration pag
 OPENBENCH_CONFIG = {
 
     # Server Client version control
-    'client_version' : '9',
+    'client_version' : '10',
 
     # Generic Error Messages useful to those setting up their own instance
     'error' : {
-        'disabled'            : 'Account has not been enabled. Contact andrew@grantnet.us',
+        'disabled'            : 'Account has not been enabled. Contact an Administrator',
         'fakeuser'            : 'This is not a real OpenBench User. Create an OpenBench account',
         'requires_login'      : 'All pages require a user login to access',
         'manual_registration' : 'Registration can only be done via an Administrator',

--- a/OpenBench/config.py
+++ b/OpenBench/config.py
@@ -18,12 +18,16 @@
 #                                                                             #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-import json, os.path
+import json, os.path, sys
 from OpenSite.settings import PROJECT_PATH
 
 def load_json_config(*path):
-    with open(os.path.join(PROJECT_PATH, *path)) as fin:
-        return json.load(fin)
+    try:
+        with open(os.path.join(PROJECT_PATH, *path)) as fin:
+            return json.load(fin)
+    except:
+        print ('Error reading ', path)
+        sys.exit()
 
 def load_folder_of_configs(*path):
     return {

--- a/OpenBench/management/commands/runserver.py
+++ b/OpenBench/management/commands/runserver.py
@@ -1,29 +1,46 @@
 import django.apps
-import threading, time
+import requests, sys, threading, time
 import OpenBench.utils
 
 from django.core.management.commands.runserver import Command as BaseRunserverCommand
 
 class ArtifactWatcher(threading.Thread):
 
+    def check_for_artifacts(self, data):
+
+        # Success, if we had all artifacts. Otherwise consider re-running the Workflow
+        retval, has_all = OpenBench.utils.fetch_artifact_url(*data, return_data=True)
+        if has_all: return retval, True
+
+        # Otherwise, we may have returned the Jobs + Artifacts
+        jobs, artifacts = retval
+
+        # Catch expired artifacts, or a Github API bug and run the Workflow
+        if all(job['conclusion'] == 'success' for job in jobs):
+            run_id = jobs[0]['run_id']
+            url    = OpenBench.utils.path_join(data[0], 'actions', 'runs', str(run_id), 'rerun')
+            requests.post(url=url, headers=data[2]).json()
+
+        # We did not have all artifacts needed, return the original source
+        return data[0], False
+
     def update_test(self, test):
 
-        dev_has_all  = test.dev.source.endswith('artifacts')
-        base_has_all = test.base.source.endswith('artifacts')
-
-        dev_headers  = OpenBench.utils.read_git_credentials(test.dev_engine)
-        base_headers = OpenBench.utils.read_git_credentials(test.base_engine)
-
-        if dev_headers and not dev_has_all:
-            test.dev.source, dev_has_all = OpenBench.utils.fetch_artifact_url(
-                test.dev.source, test.dev_engine, dev_headers, test.dev.sha)
+        # Check for Artifacts for Dev, and re-run if needed
+        if not (dev_has_all := test.dev.source.endswith('artifacts')):
+            dev_headers = OpenBench.utils.read_git_credentials(test.dev_engine)
+            data = [test.dev.source, test.dev_engine, dev_headers, test.dev.sha]
+            test.dev.source, dev_has_all = self.check_for_artifacts(data)
             test.dev.save()
 
-        if base_headers and not base_has_all:
-            test.base.source, base_has_all = OpenBench.utils.fetch_artifact_url(
-                test.base.source, test.base_engine, base_headers, test.base.sha)
+        # Check for Artifacts for Base, and re-run if needed
+        if not (base_has_all := test.base.source.endswith('artifacts')):
+            base_headers = OpenBench.utils.read_git_credentials(test.base_engine)
+            data = [test.base.source, test.base_engine, base_headers, test.base.sha]
+            test.base.source, base_has_all = self.check_for_artifacts(data)
             test.base.save()
 
+        # If both finished, flag the test as no longer awaiting
         if dev_has_all and base_has_all:
             test.awaiting = False
             test.save()
@@ -31,8 +48,12 @@ class ArtifactWatcher(threading.Thread):
     def run(self):
         while True:
             for test in OpenBench.utils.get_awaiting_tests():
-                self.update_test(test)
-            time.sleep(10)
+                try: self.update_test(test)
+                except:
+                    import traceback, sys
+                    traceback.print_exc()
+                    sys.stdout.flush()
+            time.sleep(15)
 
 class Command(BaseRunserverCommand):
 

--- a/OpenBench/models.py
+++ b/OpenBench/models.py
@@ -49,12 +49,14 @@ class Profile(Model):
 
 class Machine(Model):
 
-    user     = ForeignKey(User, PROTECT, related_name='owner')
-    mnps     = FloatField(default=0.00)
-    updated  = DateTimeField(auto_now=True)
-    secret   = CharField(max_length=64, default='None')
-    info     = JSONField()
-    workload = IntegerField(default=0)
+    user      = ForeignKey(User, PROTECT, related_name='owner')
+    mnps      = FloatField(default=0.00)
+    dev_mnps  = FloatField(default=0.00)
+    base_mnps = FloatField(default=0.00)
+    updated   = DateTimeField(auto_now=True)
+    secret    = CharField(max_length=64, default='None')
+    info      = JSONField()
+    workload  = IntegerField(default=0)
 
     def __str__(self):
         return '[%d] %s' % (self.id, self.user.username)

--- a/OpenBench/utils.py
+++ b/OpenBench/utils.py
@@ -638,6 +638,7 @@ def workload_to_dictionary(test, result):
                 'time_control' : test.dev_time_control,
                 'nps'          : OPENBENCH_CONFIG['engines'][test.dev_engine]['nps'],
                 'build'        : OPENBENCH_CONFIG['engines'][test.dev_engine]['build'],
+                'private'      : OPENBENCH_CONFIG['engines'][test.dev_engine]['private'],
             },
 
            'base' : {
@@ -652,6 +653,7 @@ def workload_to_dictionary(test, result):
                 'time_control' : test.base_time_control,
                 'nps'          : OPENBENCH_CONFIG['engines'][test.base_engine]['nps'],
                 'build'        : OPENBENCH_CONFIG['engines'][test.base_engine]['build'],
+                'private'      : OPENBENCH_CONFIG['engines'][test.base_engine]['private'],
             },
         },
     }

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -18,7 +18,7 @@
 #                                                                             #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-import os, hashlib, datetime, json, secrets, re
+import os, hashlib, datetime, json, secrets, sys, re
 
 import django.http
 import django.shortcuts
@@ -696,8 +696,11 @@ def client_submit_nps(request):
     machine, response = client_verify_worker(request)
     if response != None: return response
 
-    # Update the NPS counter for the GUI views
-    machine.mnps = float(request.POST['nps']) / 1e6; machine.save()
+    # Update the NPS counters for the GUI views
+    machine.mnps      = float(request.POST['nps'     ]) / 1e6;
+    machine.dev_mnps  = float(request.POST['dev_nps' ]) / 1e6;
+    machine.base_mnps = float(request.POST['base_nps']) / 1e6;
+    machine.save()
 
     # Pass back an empty JSON response
     return JsonResponse({})

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -590,6 +590,7 @@ def client_get_build_info(request):
     data = {}
     for engine, config in OPENBENCH_CONFIG['engines'].items():
         data[engine] = config['build']
+        data[engine]['private'] = config['private']
     return JsonResponse(data)
 
 @csrf_exempt

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -628,6 +628,10 @@ def client_worker_info(request):
         if not data['private'] and engine not in machine.info['compilers'].keys():
             continue
 
+        # Must match the Operating Systems supported by the engine
+        if machine.info['os_name'] not in data['build']['systems']:
+            continue
+
         # All requirements are met, and this Machine can play with the given engine
         machine.info['supported'].append(engine)
 

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -365,7 +365,8 @@ def test(request, id, action=None):
         return django.http.HttpResponseRedirect('/index/')
 
     if action not in ['APPROVE', 'RESTART', 'STOP', 'DELETE', 'MODIFY']:
-        return render(request, 'test.html', OpenBench.utils.get_test_context(test))
+        data = { 'test' : test, 'results': Result.objects.filter(test=test) }
+        return render(request, 'test.html', data)
 
     if not request.user.is_authenticated:
         return redirect(request, '/login/', error='Only users may interact with tests')

--- a/Templates/OpenBench/create_test.html
+++ b/Templates/OpenBench/create_test.html
@@ -132,9 +132,12 @@
 
                 <div class="row">
                     <label> Syzygy WDL </label> <select name="syzygy_wdl">
-                        <option value="OPTIONAL"> Optional</option>
-                        <option value="REQUIRED"> Required</option>
-                        <option selected value="DISABLED"> Disabled</option>
+                        <option selected value="DISABLED"> Disabled </option>
+                        <option value="OPTIONAL"> Optional </option>
+                        <option value="6-MAN"> 6-Man </option>
+                        <option value="5-MAN"> 5-Man </option>
+                        <option value="4-MAN"> 4-Man </option>
+                        <option value="3-MAN"> 3-Man </option>
                     </select>
                 </div>
 
@@ -150,9 +153,12 @@
                 <div class="row">
                     <label> Syzygy ADJ. </label>
                     <select name="syzygy_adj">
-                        <option selected value="OPTIONAL"> Optional</option>
-                        <option value="REQUIRED"> Required</option>
-                        <option value="DISABLED"> Disabled</option>
+                        <option selected value="DISABLED"> Disabled </option>
+                        <option value="OPTIONAL"> Optional </option>
+                        <option value="6-MAN"> 6-Man </option>
+                        <option value="5-MAN"> 5-Man </option>
+                        <option value="4-MAN"> 4-Man </option>
+                        <option value="3-MAN"> 3-Man </option>
                     </select>
                 </div>
                 <div class="row">

--- a/Templates/OpenBench/machine.html
+++ b/Templates/OpenBench/machine.html
@@ -25,7 +25,7 @@
             <tr><td class="td-label">Logical Cores</td><td>{{machine.info.logical_cores}}</td></tr>
             <tr><td class="td-label">Physical Cores</td><td>{{machine.info.physical_cores}}</td></tr>
             <tr><td class="td-label">Total RAM (MB)</td><td>{{machine.info.ram_total_mb}}</td></tr>
-            <tr><td class="td-label">Syzygy WDL-6</td><td>{{machine.info.syzygy_wdl}}</td></tr>
+            <tr><td class="td-label">Syzygy WDL</td><td>{{machine.info.syzygy_max}}-Man</td></tr>
 
             <tr><td class="td-label"></td><td><br></td></tr>
 

--- a/Templates/OpenBench/test.html
+++ b/Templates/OpenBench/test.html
@@ -64,6 +64,7 @@
             <tr><td class="td-label">Base Engine</td><td>{{test.base_engine}}</td></tr>
             <tr><td class="td-label">Base Source</td><td><a href="{{test.base_repo}}">{{test.base_repo}}</a></td></tr>
             <tr><td class="td-label">Base Sha</td><td>{{test.base.sha}}</td></tr>
+            <tr><td class="td-label">Base Branch</td><td>{{test.base.name|prettyName}}</td></tr>
             <tr><td class="td-label">Base Bench</td><td>{{test.base.bench}}</td></tr>
             {% if test.base_network %}
             <tr>

--- a/Templates/OpenBench/test.html
+++ b/Templates/OpenBench/test.html
@@ -173,10 +173,10 @@
                 <th style="width: 60px">Crash</th>
             </tr>
 
-            {% for id, result in results.items %}
+            {% for result in results %}
                 <tr>
-                    <td>{{result.machine_id}}</td>
-                    <td>{{result.username|capfirst}}</td>
+                    <td><a href="/machines/{{result.machine.id}}">{{result.machine.id}}</a></td>
+                    <td>{{result.machine.user.username|capfirst}}</td>
                     <td class="timestamp">{{result.updated|date:'U'}}</td>
                     <td class="numeric">{{result.games}}</td>
                     <td class="numeric">{{result.wins}}</td>


### PR DESCRIPTION
Resolves https://github.com/AndyGrant/OpenBench/issues/139
Resolves https://github.com/AndyGrant/OpenBench/issues/138
Resolves https://github.com/AndyGrant/OpenBench/issues/137
Resolves https://github.com/AndyGrant/OpenBench/issues/136
Resolves https://github.com/AndyGrant/OpenBench/issues/135
Resolves https://github.com/AndyGrant/OpenBench/issues/133
Resolves https://github.com/AndyGrant/OpenBench/issues/121


* Small CSS fixes to the test page view
* Massive cleanup for Client.py to remove globals due to Windows env. issues
* Retrigger workflow runs if they are expired, or appear to be bugged but are fine
* Collapse all results into a single object for a given machine once again
* Full fledged support for artifact selection for various vector instr. sets
* Allow specific TB for either setting, 3/4/5/6/Optional/Disabled
* Make it so the artifact name does not matter inside of openbench.yml
* Add operating systems to the JSONs to limit test distribution
* Remove the need to hard-code the artifacts that are desired
* More verbose error reporting inside the Client and the Server
* Fix number of cases during test creation that would not be detected as errors
* Rename ncutechess option to just nsockets, which is more useful
* Machines now save dev and base nps as well as the average ( not used yet )
* Optimize use case for AMD EPYC 7B12s that have good PEXT support on Zen2

Requires increase in Client + Server version, as changes are breaking. Also desires but might not require the following in the python3 manage.py shell:

```
from OpenBench.models import Machine, Result

Result.objects.all().delete()
Machine.objects.all().delete()

from OpenBench.models import Test

for t in Test.objects.all():

  if t.syzygy_wdl == 'REQUIRED':
    t.syzygy_wdl = '6-MAN'
    t.save()

  if t.syzygy_adj == 'REQUIRED':
    t.syzygy_adj = '6-MAN'
    t.save()

exit()
```