### PR TITLE
Client Reporting

### DIFF
--- a/OpenBench/config.py
+++ b/OpenBench/config.py
@@ -42,7 +42,7 @@ REQUIRE_MANUAL_REGISTRATION = False # Disable the public facing registration pag
 OPENBENCH_CONFIG = {
 
     # Server Client version control
-    'client_version' : '11',
+    'client_version' : '12',
 
     # Generic Error Messages useful to those setting up their own instance
     'error' : {


### PR DESCRIPTION
Collects results as game-pairs, instead of as individual results. This removes some noise and bias that may have existed prior.

The master thread now handles all reporting to the OpenBench server. Help threads, ( one for each --nsockets or -N ), will place their results in a `multiprocessing.Queue()`. 

We will report `report_rate`-pairs at a time. However we will only report up to once every 30 seconds. This means we might batch report many many games at a time. This acts as a natural remedy to if someone were to have created an insanely short time control, or low nodes test. This will cause fixed-game tests to go over the cap. IE, a 40,000 game test is very likely to receive a small number of games above 40,000. Fixing these seems non-trivial, and also not important. 

The Client also sends Pentanomial information to the server now. This information is not acted upon.

This involved a complete rewrite of how data (trinomial) information is extracted from Cutechess. It is predicated upon the assertion that cutechess pairs are sequential. IE, pair one will be game 1/2. Pair two will be games 3/4. Etc. This is the fundemental assertion that is in Fishtest, although very confusing to extract from observation.

Resolves an issue where the worker threads, spawned to run benchmarks, were not being killed, as `.start()` was not followed by a `.join()`. 

Makes more cleanly aborting threads, by explicitly murdering them with an abort_flag from `threading.Event()`. This speeds up killing workers that have multi-sockets. It also helps further protect us against Cutechess being left open.

Performs atomic transactions with the database for tests. This is critical for dealing with future SPSA efforts. Updates to Profile, individual Result, and Machine, are left as is. This is because `Model.objects.filter().update()` is atomic, and the contents of Results are hit by only 1-thread at a time, and Profile/Machine's updates do not matter.

Resolves https://github.com/AndyGrant/OpenBench/issues/144 and then some.