### PR TITLE
Add spsa_reporting_type and spsa_distribution_type

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -606,6 +606,10 @@ class ResultsReporter(object):
         self.last_report = 0
         self.pending     = []
 
+        # Don't report until finished, for BULK SPSA tests
+        self.bulk = self.config.workload['test']['type'] == 'SPSA'
+        self.bulk = self.bulk and self.config.workload['reporting_type'] == 'BULK'
+
         # Block up-to 5 seconds to get a new result
         def get_next_result():
             try: return self.results_queue.get(timeout=5)
@@ -618,7 +622,7 @@ class ResultsReporter(object):
                 self.pending.append(result)
 
             # Send results every 30 seconds, until all Tasks are done
-            if self.send_results(report_interval=REPORT_INTERVAL):
+            if not self.bulk and self.send_results(report_interval=REPORT_INTERVAL):
                 return
 
             # Kill everything if openbench.exit is created

--- a/OpenBench/workloads/create_workload.py
+++ b/OpenBench/workloads/create_workload.py
@@ -203,6 +203,10 @@ def extract_spas_params(request):
     spsa['pairs_per' ] = int(request.POST['spsa_pairs_per'])
     spsa['A'         ] = spsa['A_ratio'] * spsa['iterations']
 
+    # Tuning Methodologies
+    spsa['reporting_type'   ] = request.POST['spsa_reporting_type']
+    spsa['distribution_type'] = request.POST['spsa_distribution_type']
+
     # Each individual tuning parameter
     spsa['parameters'] = {}
     for line in request.POST['spsa_inputs'].split('\n'):

--- a/OpenBench/workloads/verify_workload.py
+++ b/OpenBench/workloads/verify_workload.py
@@ -111,45 +111,47 @@ def verify_tune_creation(errors, request):
 
     verifications = [
 
+        # Verify the SPSA raw inputs and methods
+        (verify_spsa_inputs           , 'spsa_inputs'),
+        (verify_spsa_reporting_type   , 'spsa_reporting_type', 'Reporting Method'),
+        (verify_spsa_distribution_type, 'spsa_distribution_type', 'Distribution Method'),
+
         # Verify everything about the Engine
-        (verify_configuration  , 'dev_engine', 'Engine', 'engines'),
-        (verify_github_repo    , 'dev_repo'),
-        (verify_network        , 'dev_network', 'Network', 'dev_engine'),
-        (verify_options        , 'dev_options', 'Threads', 'Options'),
-        (verify_options        , 'dev_options', 'Hash', 'Options'),
-        (verify_time_control   , 'dev_time_control', 'Time Control'),
+        (verify_configuration         , 'dev_engine', 'Engine', 'engines'),
+        (verify_github_repo           , 'dev_repo'),
+        (verify_network               , 'dev_network', 'Network', 'dev_engine'),
+        (verify_options               , 'dev_options', 'Threads', 'Options'),
+        (verify_options               , 'dev_options', 'Hash', 'Options'),
+        (verify_time_control          , 'dev_time_control', 'Time Control'),
 
         # Verify everything about the Test Settings
-        (verify_configuration  , 'book_name', 'Book', 'books'),
+        (verify_configuration         , 'book_name', 'Book', 'books'),
 
         # Verify everything about the General Settings
-        (verify_integer        , 'priority', 'Priority'),
-        (verify_greater_than   , 'throughput', 'Throughput', 0),
-        (verify_syzygy_field   , 'syzygy_wdl', 'Syzygy WDL'),
+        (verify_integer               , 'priority', 'Priority'),
+        (verify_greater_than          , 'throughput', 'Throughput', 0),
+        (verify_syzygy_field          , 'syzygy_wdl', 'Syzygy WDL'),
 
         # Verify everything about the Workload Settings
-        (verify_integer_or_none, 'worker_limit', 'Worker Limit'),
-        (verify_integer_or_none, 'thread_limit', 'Thread Limit'),
+        (verify_integer_or_none       , 'worker_limit', 'Worker Limit'),
+        (verify_integer_or_none       , 'thread_limit', 'Thread Limit'),
 
         # Verify everything about the Adjudicaton Settings
-        (verify_syzygy_field   , 'syzygy_adj', 'Syzygy Adjudication'),
-        (verify_win_adj        , 'win_adj'),
-        (verify_draw_adj       , 'draw_adj'),
+        (verify_syzygy_field          , 'syzygy_adj', 'Syzygy Adjudication'),
+        (verify_win_adj               , 'win_adj'),
+        (verify_draw_adj              , 'draw_adj'),
 
         # Verify everything about the SPSA Settings
-        (verify_float          , 'spsa_alpha', 'SPSA A-Ratio'),
-        (verify_float          , 'spsa_alpha', 'SPSA Alpha'),
-        (verify_float          , 'spsa_gamma', 'SPSA Gamma'),
-        (verify_integer        , 'spsa_iterations', 'SPSA Iterations'),
-        (verify_integer        , 'spsa_pairs_per', 'SPSA Pairs-Per'),
-        (verify_greater_than   , 'spsa_alpha', 'SPSA A-Ratio', 0.00),
-        (verify_greater_than   , 'spsa_alpha', 'SPSA Alpha', 0.00),
-        (verify_greater_than   , 'spsa_gamma', 'SPSA Gamma', 0.00),
-        (verify_greater_than   , 'spsa_iterations', 'SPSA Iterations', 0),
-        (verify_greater_than   , 'spsa_pairs_per', 'SPSA Pairs-Per', 0),
-
-        # Verify the SPSA raw inputs for each parameter
-        (verify_spsa_inputs    , 'spsa_inputs'),
+        (verify_float                 , 'spsa_alpha', 'SPSA A-Ratio'),
+        (verify_float                 , 'spsa_alpha', 'SPSA Alpha'),
+        (verify_float                 , 'spsa_gamma', 'SPSA Gamma'),
+        (verify_integer               , 'spsa_iterations', 'SPSA Iterations'),
+        (verify_integer               , 'spsa_pairs_per', 'SPSA Pairs-Per'),
+        (verify_greater_than          , 'spsa_alpha', 'SPSA A-Ratio', 0.00),
+        (verify_greater_than          , 'spsa_alpha', 'SPSA Alpha', 0.00),
+        (verify_greater_than          , 'spsa_gamma', 'SPSA Gamma', 0.00),
+        (verify_greater_than          , 'spsa_iterations', 'SPSA Iterations', 0),
+        (verify_greater_than          , 'spsa_pairs_per', 'SPSA Pairs-Per', 0),
     ]
 
     for verification in verifications:
@@ -267,6 +269,16 @@ def verify_spsa_inputs(errors, request, field):
     except:
         traceback.print_exc()
         errors.append('Malformed SPSA Input')
+
+def verify_spsa_reporting_type(errors, request, field, field_name):
+    candidates = ['BULK', 'BATCHED']
+    try: assert request.POST[field] in candidates
+    except: errors.append('%s must be in %s' % (field_name, ', '.join(candidates)))
+
+def verify_spsa_distribution_type(errors, request, field, field_name):
+    candidates = ['SINGLE', 'MULTIPLE']
+    try: assert request.POST[field] in candidates
+    except: errors.append('%s must be in %s' % (field_name, ', '.join(candidates)))
 
 
 def collect_github_info(errors, request, field):

--- a/Templates/OpenBench/base.html
+++ b/Templates/OpenBench/base.html
@@ -86,7 +86,7 @@
             <ul>
                 <li class="header">Actions</li>
                 <li><a href="/newTest"><i class="fa-solid fa-plus fa-fw"></i> Create Test</a></li>
-                <li><a href="/newTune"><i class="fa-solid fa-plus fa-fw"></i> Create Tune</a></li>
+                <li><a href="/newTune"><i class="fa-solid fa-vial fa-fw"></i> Create Tune</a></li>
                 <li><a href="/newNetwork"><i class="fa-solid fa-upload fa-fw"></i> Upload Net</a></li>
             </ul>
 

--- a/Templates/OpenBench/create_tune.html
+++ b/Templates/OpenBench/create_tune.html
@@ -60,11 +60,26 @@
                     <label> Time </label> <input id="time_control" name="dev_time_control">
                 </div>
 
+                <h3> SPSA Methodologies </h3>
+
+                <div class="row">
+                    <label> Reporting </label> <select name="spsa_reporting_type">
+                        <option selected value="BATCHED"> Batched </option>
+                        <option value="BULK"> Bulk </option>
+                    </select>
+                </div>
+
+                <div class="row">
+                    <label> Distribution </label> <select name="spsa_distribution_type">
+                        <option selected value="SINGLE"> Single </option>
+                        <option value="MULTIPLE"> Multiple </option>
+                    </select>
+                </div>
+
                 <h3> SPSA Input </h3>
 
                 <div class="row">
-
-                    <textarea style="margin-left:24px" id="spsa_inputs" name="spsa_inputs" rows=17></textarea>
+                    <textarea style="margin-left:24px" id="spsa_inputs" name="spsa_inputs" rows=9></textarea>
                 </div>
 
             </div>

--- a/Templates/OpenBench/tune.html
+++ b/Templates/OpenBench/tune.html
@@ -67,7 +67,9 @@
             <tr><td class="td-label">Draw ADJ.</td><td>{{test.draw_adj}}</td></tr>
             <tr><td class="td-label">Alpha</td><td>{{test.spsa.Alpha}}</td></tr>
             <tr><td class="td-label">Gamma</td><td>{{test.spsa.Gamma}}</td></tr>
-            <tr><td class="td-label">A-Ratio</td><td>{{test.spsa.A}}</td></tr>
+            <tr><td class="td-label">A-Ratio</td><td>{{test.spsa.A_ratio}}</td></tr>
+            <tr><td class="td-label">Reporting Method</td><td>{{test.spsa.reporting_type}}</td></tr>
+            <tr><td class="td-label">Distribution Method</td><td>{{test.spsa.distribution_type}}</td></tr>
         </table>
     </div>
 


### PR DESCRIPTION

1. Reporting Method (BATCHED vs BULK) for SPSA Tests 
   Send everything at once, vs every time a pair finishes

2. Distribution Method (SINGLE vs MULTIPLE) for SPSA Tests 
   Give 1 parameter set; Give as many sets as we can

Also fix a display bug in A-Ratio; Change the Tuning icon; Fix a comment that said SPRT instead of SPSA; 