### PR TITLE
Some improvements to CSS/HTML/JS

### DIFF
--- a/OpenBench/static/copy_text.js
+++ b/OpenBench/static/copy_text.js
@@ -1,0 +1,24 @@
+
+function copy_text(element_id, keep_url) {
+
+    var text = document.getElementById(element_id).innerHTML;
+    text = text.replace(/<br>/g, "\n");
+
+    if (keep_url)
+        text += "\n" + window.location.href;
+
+    var area = document.createElement("textarea");
+    area.value = text;
+    document.body.append(area);
+    area.select();
+
+    try {
+        document.execCommand("copy");
+        document.body.removeChild(area);
+    }
+
+    catch (err) {
+        document.body.removeChild(area);
+        console.error("Unable to copy to Clipboard");
+    }
+}

--- a/OpenBench/templatetags/mytags.py
+++ b/OpenBench/templatetags/mytags.py
@@ -238,18 +238,28 @@ def spsa_param_digest(test):
     c_compression = iteration ** test.spsa['Gamma']
     r_compression = (test.spsa['A'] + iteration) ** test.spsa['Alpha']
 
-    for name, param in test.spsa['parameters'].items():
+    # Maintain the original order, if there was one
+    keys = sorted(
+        test.spsa['parameters'].keys(),
+        key=lambda x: test.spsa['parameters'][x].get('index', -1)
+    )
+
+    for name in keys:
+
+        param = test.spsa['parameters'][name]
 
         # C and R if we got a workload right now
         c = param['c'] / c_compression
         r = param['a'] / r_compression / c ** 2
 
+        fstr = '%.4f' if param['float'] else '%d'
+
         digest.append([
             name,
-            '%.4f' % (param['start']),
             '%.4f' % (param['value']),
-            '%.4f' % (param['min'  ]),
-            '%.4f' % (param['max'  ]),
+            fstr   % (param['start']),
+            fstr   % (param['min'  ]),
+            fstr   % (param['max'  ]),
             '%.4f' % (c),
             '%.4f' % (param['c_end']),
             '%.4f' % (r),
@@ -258,7 +268,35 @@ def spsa_param_digest(test):
 
     return digest
 
+def spsa_original_input(test):
+
+    # Maintain the original order, if there was one
+    keys = sorted(
+        test.spsa['parameters'].keys(),
+        key=lambda x: test.spsa['parameters'][x].get('index', -1)
+    )
+
+    lines = []
+    for name in keys:
+
+        param = test.spsa['parameters'][name]
+        dtype = 'float' if param['float'] else 'int'
+
+        # Original 7 token Input
+        lines.append(', '.join([
+            name,
+            dtype,
+            str(param['start']),
+            str(param['min'  ]),
+            str(param['max'  ]),
+            str(param['c_end']),
+            str(param['r_end']),
+        ]))
+
+    return '\n'.join(lines)
+
 register.filter('spsa_param_digest', spsa_param_digest)
+register.filter('spsa_original_input', spsa_original_input)
 
 
 

--- a/OpenBench/workloads/create_workload.py
+++ b/OpenBench/workloads/create_workload.py
@@ -209,12 +209,16 @@ def extract_spas_params(request):
 
     # Each individual tuning parameter
     spsa['parameters'] = {}
-    for line in request.POST['spsa_inputs'].split('\n'):
+    for index, line in enumerate(request.POST['spsa_inputs'].split('\n')):
 
         # Comma-seperated values, already verified in verify_workload()
         name, data_type, value, minimum, maximum, c_end, r_end = line.split(',')
 
-        param          = {} # Raw extraction
+        # Recall the original order of inputs
+        param          = {}
+        param['index'] = index
+
+        # Raw extraction
         param['float'] = data_type.strip() == 'float'
         param['start'] = float(value)
         param['value'] = float(value)

--- a/Templates/OpenBench/test.html
+++ b/Templates/OpenBench/test.html
@@ -1,44 +1,13 @@
 {% extends "OpenBench/base.html" %}
 
 {% load mytags %}
+{% load static %}
 
 {% block style %}
 {% endblock %}
 
 {% block scripts %}
-
-    <script>
-
-        function copy_statblock() {
-
-            var text = document.getElementById("long-statblock").innerHTML;
-            text = text.replace(/<br>/g, "\n");
-            text += "\n" + window.location.href;
-
-            // navigator.clipboard.writeText(text); // Optimal solution
-
-            // Suboptimal, HTTP solution
-
-            var area = document.createElement("textarea");
-            area.value = text;
-            document.body.append(area);
-
-            area.focus();
-            area.select();
-
-            try {
-                document.execCommand("copy");
-                document.body.removeChild(area);
-            }
-
-            catch (err) {
-                document.body.removeChild(area);
-                console.error("Unable to copy to Clipboard");
-            }
-        }
-
-    </script>
-
+    <script src="{% static 'copy_text.js' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -132,7 +101,7 @@
         {% endif %}
 
         <!-- Copy Button: Copy the current results statblock -->
-        <a class="copy-button" onclick="copy_statblock()">
+        <a class="copy-button" onclick="copy_text('long-statblock', true)">
             <i class="fa-regular fa-clone copy-button"></i>
         </a>
 

--- a/Templates/OpenBench/tune.html
+++ b/Templates/OpenBench/tune.html
@@ -151,7 +151,11 @@
             {% for row in test|spsa_param_digest %}
                 <tr>
                     {% for element in row %}
-                        <td class='numeric'> {{ element }} </td>
+                        {% if not forloop.first %}
+                            <td class='numeric'> {{ element }} </td>
+                        {% else %}
+                            <td> {{ element }} </td>
+                        {% endif %}
                     {% endfor %}
                 <tr>
             {% endfor %}

--- a/Templates/OpenBench/tune.html
+++ b/Templates/OpenBench/tune.html
@@ -1,44 +1,13 @@
 {% extends "OpenBench/base.html" %}
 
 {% load mytags %}
+{% load static %}
 
 {% block style %}
 {% endblock %}
 
 {% block scripts %}
-
-    <script>
-
-        function copy_statblock() {
-
-            var text = document.getElementById("long-statblock").innerHTML;
-            text = text.replace(/<br>/g, "\n");
-            text += "\n" + window.location.href;
-
-            // navigator.clipboard.writeText(text); // Optimal solution
-
-            // Suboptimal, HTTP solution
-
-            var area = document.createElement("textarea");
-            area.value = text;
-            document.body.append(area);
-
-            area.focus();
-            area.select();
-
-            try {
-                document.execCommand("copy");
-                document.body.removeChild(area);
-            }
-
-            catch (err) {
-                document.body.removeChild(area);
-                console.error("Unable to copy to Clipboard");
-            }
-        }
-
-    </script>
-
+    <script src="{% static 'copy_text.js' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -122,8 +91,9 @@
             {% endif %}
         {% endif %}
 
-        <!-- Copy Button: Copy the current results statblock -->
-        <a class="copy-button" onclick="copy_statblock()">
+        <!-- Copies Raw SPSA Input from a hidden element -->
+        <pre id="spsa-input" style="display: none">{{test|spsa_original_input}}</pre>
+        <a class="copy-button" onclick="copy_text('spsa-input', false)">
             <i class="fa-regular fa-clone copy-button"></i>
         </a>
 
@@ -152,6 +122,7 @@
                         <label>Thread Limit</label>
                         <input value="{{test.thread_limit|default:'None'}}" name="thread_limit">
                     </div>
+
                     <!-- Edit Button: For Approvers or Test Authors -->
                     {% if profile.approver or profile.user.username == test.author %}
                     <input class="anchorbutton btn-blue w-100" type="submit" name="submit" value="Modify">
@@ -167,8 +138,8 @@
         <table class="stripes wrappable">
             <tr class="table-header">
                 <th> Name </th>
-                <th> Start </th>
                 <th> Curr </th>
+                <th> Start </th>
                 <th> Min </th>
                 <th> Max </th>
                 <th> C </th>
@@ -180,7 +151,7 @@
             {% for row in test|spsa_param_digest %}
                 <tr>
                     {% for element in row %}
-                        <td> {{ element }} </td>
+                        <td class='numeric'> {{ element }} </td>
                     {% endfor %}
                 <tr>
             {% endfor %}


### PR DESCRIPTION
* Move the copy_text function to /static
* Record the original order of inputs for SPSA
* Display SPSA data in the original order ( if it exists )
* Format ints as ints instead of floats for Start/Min/Max
* Swap the Curr/Start column to clearly show the initial triplet
* Right align all of the SPSA stuff
* Change the copy button on Tunes to be the original SPSA Input