### PR TITLE
Allow uploading PGNs to the server for tests

### DIFF
--- a/Client/pgn_util.py
+++ b/Client/pgn_util.py
@@ -36,8 +36,16 @@ def pgn_list_to_headers(lines):
     return { f.split()[0][1:] : re.search(r'"([^"]*)"', f).group(1) for f in lines }
 
 def pgn_strip_headers(headers):
+
+    # First 7 + FEN are required. Rest are useful.
+    desired = [
+        'Event', 'Site', 'Date',
+        'Round', 'White', 'Black',
+        'Result', 'PlyCount', 'FEN',
+        'TimeControl', 'Variant'
+    ]
+
     # PGN Format: [<Header> "<Value>"]
-    desired = [ 'White', 'Black', 'Result', 'PlyCount', 'FEN', 'TimeControl' ]
     return '\n'.join('[%s "%s"]' % (f, headers[f]) for f in desired if f in headers)
 
 def pgn_strip_movelist(move_text, compact):

--- a/Client/pgn_util.py
+++ b/Client/pgn_util.py
@@ -38,7 +38,7 @@ def pgn_list_to_headers(lines):
 def pgn_strip_headers(headers):
     # PGN Format: [<Header> "<Value>"]
     desired = [ 'White', 'Black', 'Result', 'PlyCount', 'FEN', 'TimeControl' ]
-    return '\n'.join('[%s "%s"]' % (f, headers[f]) for f in desired)
+    return '\n'.join('[%s "%s"]' % (f, headers[f]) for f in desired if f in headers)
 
 def pgn_strip_movelist(move_text, compact):
 
@@ -61,18 +61,20 @@ def pgn_strip_movelist(move_text, compact):
     # PGNs expect trailing game result text
     return stripped + result_regex.search(move_text).group(1)
 
-def strip_entire_pgn(file_name, compact=True):
+def strip_entire_pgn(file_name, compact):
 
     stripped = ''
-    for header_dict, move_text in pgn_iterator(sys.argv[1]):
-        stripped += pgn_strip_headers(header_dict) + '\n'
-        stripped += pgn_strip_movelist(move_text, compact) + '\n'
+    for header_dict, move_text in pgn_iterator(file_name):
+        stripped += pgn_strip_headers(header_dict) + '\n\n'
+        stripped += pgn_strip_movelist(move_text, compact) + '\n\n'
 
     return stripped
 
+def compress_list_of_pgns(file_names, compact):
 
-if __name__ == '__main__':
+    text = ''
+    for fname in file_names:
+        print ('Compressing %s...' % (fname))
+        text += strip_entire_pgn(fname, compact)
 
-    text = strip_entire_pgn(sys.argv[1], compact=True)
-
-    compressed = bz2.compress(text.encode())
+    return bz2.compress(text.encode())

--- a/Client/pgn_util.py
+++ b/Client/pgn_util.py
@@ -1,0 +1,78 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#                                                                           #
+#   OpenBench is a chess engine testing framework by Andrew Grant.          #
+#   <https://github.com/AndyGrant/OpenBench>  <andrew@grantnet.us>          #
+#                                                                           #
+#   OpenBench is free software: you can redistribute it and/or modify       #
+#   it under the terms of the GNU General Public License as published by    #
+#   the Free Software Foundation, either version 3 of the License, or       #
+#   (at your option) any later version.                                     #
+#                                                                           #
+#   OpenBench is distributed in the hope that it will be useful,            #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#   GNU General Public License for more details.                            #
+#                                                                           #
+#   You should have received a copy of the GNU General Public License       #
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.   #
+#                                                                           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+import bz2
+import re
+import sys
+
+def pgn_iterator(fname):
+    with open(fname) as pgn:
+        while True:
+            headers   = pgn_list_to_headers(iter(lambda: pgn.readline().rstrip(), ''))
+            move_list = ' '.join(iter(lambda: pgn.readline().rstrip(), ''))
+            if not headers or not move_list:
+                break
+            yield (headers, move_list)
+
+def pgn_list_to_headers(lines):
+    # PGN Format: [<Header> "<Value>"]
+    return { f.split()[0][1:] : re.search(r'"([^"]*)"', f).group(1) for f in lines }
+
+def pgn_strip_headers(headers):
+    # PGN Format: [<Header> "<Value>"]
+    desired = [ 'White', 'Black', 'Result', 'PlyCount', 'FEN', 'TimeControl' ]
+    return '\n'.join('[%s "%s"]' % (f, headers[f]) for f in desired)
+
+def pgn_strip_movelist(move_text, compact):
+
+    if not compact: # Captures Score Depth/SelDepth Time Nodes
+        comment_regex = r'([+-]?M?\d+(?:\.\d+)? \d+/\d+ \d+ \d+)[^}]*'
+
+    else: # Captures Score and nothing else
+        comment_regex = r'([+-]?M?\d+(?:\.\d+)?) \d+/\d+ \d+ \d+[^}]*'
+
+    # Captures the Move and Comment, discarding extra commentary and move numbers
+    one_ply_regex = re.compile(r'\s*(?:\d+\. )?([a-zA-Z0-9+=#-]+) {%s}' % (comment_regex))
+
+    # Captures the trailing game result
+    result_regex  = re.compile(r'\s*(1-0|0-1|1/2-1/2|\*)')
+
+    stripped = '' # Add each: <Move> {<Comment>}
+    for move, comment in one_ply_regex.findall(move_text):
+        stripped += '%s {%s} ' % (move, comment)
+
+    # PGNs expect trailing game result text
+    return stripped + result_regex.search(move_text).group(1)
+
+def strip_entire_pgn(file_name, compact=True):
+
+    stripped = ''
+    for header_dict, move_text in pgn_iterator(sys.argv[1]):
+        stripped += pgn_strip_headers(header_dict) + '\n'
+        stripped += pgn_strip_movelist(move_text, compact) + '\n'
+
+    return stripped
+
+
+if __name__ == '__main__':
+
+    text = strip_entire_pgn(sys.argv[1], compact=True)
+
+    compressed = bz2.compress(text.encode())

--- a/Client/worker.py
+++ b/Client/worker.py
@@ -462,6 +462,7 @@ class Cutechess:
         options = config.workload['test'][branch]['options']
         network = config.workload['test'][branch]['network']
         private = config.workload['test'][branch]['private']
+        engine  = config.workload['test'][branch]['engine']
         syzygy  = config.workload['test']['syzygy_wdl']
 
         # Human-readable name, and scale the time control
@@ -488,7 +489,7 @@ class Cutechess:
 
         # Join options together in the Cutechess format
         options = ' option.'.join([''] + re.findall(r'"[^"]*"|\S+', options))
-        return '-engine dir=Engines/ cmd=./%s proto=uci %s%s name=%s' % (command, control, options, branch)
+        return '-engine dir=Engines/ cmd=./%s proto=uci %s%s name=%s-%s' % (command, control, options, engine, branch)
 
     @staticmethod
     def pgnout_settings(config, timestamp, cutechess_idx):

--- a/Client/worker.py
+++ b/Client/worker.py
@@ -50,7 +50,7 @@ from pgn_util import compress_list_of_pgns
 
 ## Basic configuration of the Client. These timeouts can be changed at will
 
-CLIENT_VERSION   = 22 # Client version to send to the Server
+CLIENT_VERSION   = 23 # Client version to send to the Server
 TIMEOUT_HTTP     = 30 # Timeout in seconds for HTTP requests
 TIMEOUT_ERROR    = 10 # Timeout in seconds when any errors are thrown
 TIMEOUT_WORKLOAD = 30 # Timeout in seconds between workload requests
@@ -405,8 +405,6 @@ class ServerReporter:
         files = {
             'file' : ('games.pgn', compressed_pgn_text)
         }
-
-        print (type(compressed_pgn_text))
 
         return ServerReporter.report(config, 'clientSubmitPGN', payload, files)
 

--- a/Config/config.json
+++ b/Config/config.json
@@ -1,5 +1,5 @@
 {
-    "client_version"  : 22,
+    "client_version"  : 23,
     "client_repo_url" : "https://github.com/AndyGrant/OpenBench",
     "client_repo_ref" : "master",
 

--- a/Engines/Torch.json
+++ b/Engines/Torch.json
@@ -29,20 +29,23 @@
             "both_options"      : "Threads=1 Hash=64 Minimal=true",
             "both_time_control" : "60.0+0.6",
             "workload_size"     : 8,
-            "test_bounds"       : "[0.00, 2.25]"
+            "test_bounds"       : "[0.00, 2.25]",
+            "upload_pgns"       : "COMPACT"
         },
 
         "SMP STC" : {
             "both_options"      : "Threads=6 Hash=128 Minimal=true",
             "both_time_control" : "10.0+0.1",
-            "workload_size"     : 64
+            "workload_size"     : 64,
+            "upload_pgns"       : "COMPACT"
         },
 
         "SMP LTC" : {
             "both_options"      : "Threads=15 Hash=256 Minimal=true",
             "both_time_control" : "30.0+0.3",
             "workload_size"     : 16,
-            "test_bounds"       : "[0.50, 2.50]"
+            "test_bounds"       : "[0.50, 2.50]",
+            "upload_pgns"       : "COMPACT"
         },
 
         "STC Simplification" : {
@@ -56,7 +59,8 @@
             "both_options"      : "Threads=1 Hash=64 Minimal=true",
             "both_time_control" : "60.0+0.6",
             "workload_size"     : 8,
-            "test_bounds"       : "[-1.75, 0.25]"
+            "test_bounds"       : "[-1.75, 0.25]",
+            "upload_pgns"       : "COMPACT"
         },
 
         "STC Regression" : {
@@ -72,7 +76,8 @@
             "both_time_control" : "60.0+0.6",
             "workload_size"     : 8,
             "book_name"         : "8moves_v3.epd",
-            "test_max_games"    : 40000
+            "test_max_games"    : 40000,
+            "upload_pgns"       : "COMPACT"
         },
 
         "STC Fixed Games" : {

--- a/Engines/Torch.json
+++ b/Engines/Torch.json
@@ -104,6 +104,12 @@
 
     "tune_presets" : {
 
+        "default" : {
+            "book_name"       : "UHO_4060_v2.epd",
+            "win_adj"         : "movecount=5 score=300",
+            "draw_adj"        : "movenumber=32 movecount=6 score=8"
+        },
+
         "STC" : {
             "dev_options"      : "Threads=1 Hash=16 Minimal=true",
             "dev_time_control" : "10.0+0.10"

--- a/OpenBench/config.py
+++ b/OpenBench/config.py
@@ -126,6 +126,7 @@ def verify_engine_test_preset(test_preset):
         'test_max_games',
 
         'book_name',
+        'upload_pgns',
         'priority',
         'throughput',
         'workload_size',
@@ -159,6 +160,7 @@ def verify_engine_tune_preset(tune_preset):
         'spsa_pairs_per',
 
         'book_name',
+        'upload_pgns',
         'priority',
         'throughput',
         'syzygy_wdl',

--- a/OpenBench/models.py
+++ b/OpenBench/models.py
@@ -90,7 +90,8 @@ class Result(Model):
 class Test(Model):
 
     # Misc information
-    author    = CharField(max_length=64)
+    author      = CharField(max_length=64)
+    upload_pgns = CharField(max_length=16, default='FALSE')
 
     # Opening book settings
     book_name  = CharField(max_length=32)
@@ -194,3 +195,6 @@ class Network(Model):
 
     def __str__(self):
         return '[{}] {} ({})'.format(self.engine, self.name, self.sha256)
+
+class PGN(Model):
+    pass

--- a/OpenBench/models.py
+++ b/OpenBench/models.py
@@ -197,4 +197,13 @@ class Network(Model):
         return '[{}] {} ({})'.format(self.engine, self.name, self.sha256)
 
 class PGN(Model):
-    pass
+
+    test_id    = IntegerField(default=0)
+    result_id  = IntegerField(default=0)
+    book_index = IntegerField(default=0)
+
+    def __str__(self):
+        return self.filename()
+
+    def filename(self):
+        return '%s.%s.%s.pgn.bz2' % (self.test_id, self.result_id, self.book_index)

--- a/OpenBench/templatetags/mytags.py
+++ b/OpenBench/templatetags/mytags.py
@@ -226,7 +226,7 @@ def spsa_param_digest(workload):
     digest = []
 
     # C and R are compressed as we progress iterations
-    iteration     = 10000 + (workload.games / (workload.spsa['pairs_per'] * 2))
+    iteration     = 1 + (workload.games / (workload.spsa['pairs_per'] * 2))
     c_compression = iteration ** workload.spsa['Gamma']
     r_compression = (workload.spsa['A'] + iteration) ** workload.spsa['Alpha']
 

--- a/OpenBench/urls.py
+++ b/OpenBench/urls.py
@@ -79,6 +79,7 @@ urlpatterns = [
     django.urls.path(r'clientSubmitError/', OpenBench.views.client_submit_error),
     django.urls.path(r'clientSubmitResults/', OpenBench.views.client_submit_results),
     django.urls.path(r'clientHeartbeat/', OpenBench.views.client_heartbeat),
+    django.urls.path(r'clientSubmitPGN/', OpenBench.views.client_submit_pgn),
 
     # Nice endpoints, which can be hit from the website or with credentials cleanly
     django.urls.path(r'api/config/', OpenBench.views.api_configs),

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -758,6 +758,22 @@ def client_heartbeat(request, machine):
     test = Test.objects.get(id=int(request.POST['test_id']))
     return JsonResponse([{}, { 'stop' : True }][test.finished])
 
+@csrf_exempt
+@verify_worker
+def client_submit_pgn(request, machine):
+
+    # Format: test.result.book-index.pgn.bz2
+    pgn            = PGN()
+    pgn.test_id    = int(request.POST['test_id']   )
+    pgn.result_id  = int(request.POST['result_id'] )
+    pgn.book_index = int(request.POST['book_index'])
+    pgn.save()
+
+    # Save the .pgn.bz2 to /Media/
+    FileSystemStorage().save(pgn.filename(), ContentFile(request.FILES['file'].read()))
+
+    return JsonResponse({})
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #                                                                             #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/OpenBench/workloads/create_workload.py
+++ b/OpenBench/workloads/create_workload.py
@@ -105,6 +105,7 @@ def create_new_test(request):
     test                   = Test()
     test.author            = request.user.username
     test.book_name         = request.POST['book_name']
+    test.upload_pgns       = request.POST['upload_pgns']
 
     test.dev               = get_engine(*dev_info)
     test.dev_repo          = request.POST['dev_repo']
@@ -169,6 +170,7 @@ def create_new_tune(request):
     test                  = Test()
     test.author           = request.user.username
     test.book_name        = request.POST['book_name']
+    test.upload_pgns      = request.POST['upload_pgns']
 
     test.dev              = test.base              = get_engine(*dev_info)
     test.dev_repo         = test.base_repo         = request.POST['dev_repo']

--- a/OpenBench/workloads/get_workload.py
+++ b/OpenBench/workloads/get_workload.py
@@ -158,6 +158,7 @@ def workload_to_dictionary(test, result, machine):
         'win_adj'       : test.win_adj,
         'draw_adj'      : test.draw_adj,
         'workload_size' : test.workload_size,
+        'upload_pgns'   : test.upload_pgns,
     }
 
     workload['test']['book'] = {

--- a/OpenBench/workloads/verify_workload.py
+++ b/OpenBench/workloads/verify_workload.py
@@ -82,6 +82,7 @@ def verify_test_creation(errors, request):
 
         # Verify everything about the Test Settings
         (verify_configuration  , 'book_name', 'Book', 'books'),
+        (verify_upload_pgns    , 'upload_pgns', 'Upload PGNs'),
         (verify_test_mode      , 'test_mode'),
         (verify_sprt_bounds    , 'test_bounds'),
         (verify_sprt_conf      , 'test_confidence'),
@@ -124,6 +125,7 @@ def verify_tune_creation(errors, request):
 
         # Verify everything about the Test Settings
         (verify_configuration         , 'book_name', 'Book', 'books'),
+        (verify_upload_pgns           , 'upload_pgns', 'Upload PGNs'),
 
         # Verify everything about the General Settings
         (verify_integer               , 'priority', 'Priority'),
@@ -269,6 +271,10 @@ def verify_spsa_distribution_type(errors, request, field, field_name):
     candidates = ['SINGLE', 'MULTIPLE']
     try: assert request.POST[field] in candidates
     except: errors.append('%s must be in %s' % (field_name, ', '.join(candidates)))
+
+def verify_upload_pgns(errors, request, field, field_name):
+    try: request.POST[field] in ['FALSE', 'COMPACT', 'VERBOSE']
+    except: errors.append('"%s" must be FALSE, COMPACT, or VERBOSE' % (field_name))
 
 
 def collect_github_info(errors, request, field):

--- a/Templates/OpenBench/create_workload.html
+++ b/Templates/OpenBench/create_workload.html
@@ -187,6 +187,15 @@
                 </div>
 
                 <div class="row">
+                    <label for="upload_pgns"> Upload PGNs </label>
+                    <select id="upload_pgns" name="upload_pgns">
+                        <option selected value="FALSE"> False </option>
+                        <option value="COMPACT"> Compact </option>
+                        <option value="VERBOSE"> Verbose </option>
+                    </select>
+                </div>
+
+                <div class="row">
                     <label for="priority"> Priority </label> <input value="0" id="priority" name="priority">
                 </div>
 

--- a/Templates/OpenBench/test.html
+++ b/Templates/OpenBench/test.html
@@ -41,6 +41,7 @@
             <tr><td class="td-label">Base Options</td><td>{{test.base_options}}</td></tr>
             <tr><td class="td-label">Base Time</td><td>{{test.base_time_control}}</td></tr>
             <tr><td class="td-label">Opening Book</td><td><a href="{{test|book_download_link}}">{{test.book_name}}</a></td></tr>
+            <tr><td class="td-label">Upload PGNs</td><td>{{test.upload_pgns}}</td></tr>
             <tr><td class="td-label">Syzygy WDL</td><td>{{test.syzygy_wdl}}</td></tr>
             <tr><td class="td-label">Syzygy ADJ.</td><td>{{test.syzygy_adj}}</td></tr>
             <tr><td class="td-label">Win ADJ.</td><td>{{test.win_adj}}</td></tr>


### PR DESCRIPTION
Creates a new option on tests for PGN uploading. The options are...
1. False -- Don't upload
2. Verbose -- Upload without all comment data, ie {eval depth/seldepth time-ms nodes}
3. Compact -- Upload with minimal comment data, ie {eval}

PGNs are stripped heavily, to a mostly-legal format, which includes all needed headers. The only known illegality in the PGN is that the movelist spans greater than 255 characters, which is mentioned as being illegal in the specification. The removal of the movenumbers is perfectly legal. 

The API is not included in this commit for downloading the PGNs. 