### PR TITLE
Add priority group headings

### DIFF
--- a/OpenBench/static/style.css
+++ b/OpenBench/static/style.css
@@ -161,6 +161,12 @@ body, html, main{
     background-color: #171717;
 }
 
+#content .table-small-header th {
+    color: var(--color-font3);
+    font-size: small;
+    background-color: #171717;
+}
+
 /* Table Spacer for chaining Tables as a hack */
 
 #content .table-spacer th, #content .table-spacer tr {

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -251,6 +251,14 @@ def profile_config(request):
 #                               TEST LIST VIEWS                               #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+def priority_grouped(active):
+    active_grouped = []
+    for t in active:
+        if len(active_grouped) == 0 or active_grouped[-1]["priority"] != t.priority:
+            active_grouped.append({"priority": t.priority, "tests": []})
+        active_grouped[-1]["tests"].append(t)
+    return active_grouped
+
 def index(request, page=1):
 
     pending   = OpenBench.utils.get_pending_tests()
@@ -262,7 +270,7 @@ def index(request, page=1):
 
     data = {
         'pending'   : pending,
-        'active'    : active,
+        'active'    : priority_grouped(active),
         'completed' : completed[start:end],
         'awaiting'  : awaiting,
         'paging'    : paging,
@@ -282,7 +290,7 @@ def user(request, username, page=1):
 
     data = {
         'pending'   : pending,
-        'active'    : active,
+        'active'    : priority_grouped(active),
         'completed' : completed[start:end],
         'awaiting'  : awaiting,
         'paging'    : paging,

--- a/Templates/OpenBench/index.html
+++ b/Templates/OpenBench/index.html
@@ -32,10 +32,13 @@
             <!-- Currently Running tests (Waiting to be completed) -->
             {% if active %}
                 <tr class="table-header"><th colspan='6'>Active {{status}}</th></tr>
-                {% for test in active %}
-                    <tr>
-                        {% include "OpenBench/Blocks/testsummary.html" %}
-                    </tr>
+                {% for group in active %}
+                    <tr class="table-small-header"><th colspan='6'>Priority {{group.priority}}</th></tr>
+                    {% for test in group.tests %}
+                        <tr>
+                            {% include "OpenBench/Blocks/testsummary.html" %}
+                        </tr>
+                    {% endfor %}
                 {% endfor %}
                 <tr class="table-spacer"><th colspan='6'></th></tr>
             {% endif %}


### PR DESCRIPTION
Adds headers to the active tests view indicating the priority level of the tests below it.

![image](https://github.com/AndyGrant/OpenBench/assets/10615311/2f1d6b5e-b721-4a82-8651-fd62960bfa8f)

In `master`, this information is somewhat hinted at by the order in which tests are displayed, but it is difficult to determine, for example, which tests are making progress. With this patch, this can be determined at a glance.