### PR TITLE
Allow for --focus ENGINE1 [ENGINE2 ....] to prioritize Workload Assignments

### DIFF
--- a/Client/client.py
+++ b/Client/client.py
@@ -74,24 +74,37 @@ def parse_arguments():
     req_pass   = 'OPENBENCH_PASSWORD' not in os.environ
     req_server = 'OPENBENCH_SERVER'   not in os.environ
 
-    help_user   = 'Username. May also be passed as OPENBENCH_USERNAME environment variable'
-    help_pass   = 'Password. May also be passed as OPENBENCH_PASSWORD environment variable'
-    help_server = 'Server URL. May also be passed as OPENBENCH_SERVER environment variable'
+    help_user   = 'Username. May also be provided via OPENBENCH_USERNAME environment variable'
+    help_pass   = 'Password. May also be provided via OPENBENCH_PASSWORD environment variable'
+    help_server = 'Server URL. May also be provided via OPENBENCH_SERVER environment variable'
+
+    # Pretty formatting
+    p = argparse.ArgumentParser(
+        formatter_class=lambda prog:
+            argparse.ArgumentDefaultsHelpFormatter(prog, max_help_position=10)
+    )
 
     # Create and parse all arguments into a raw format
-    p = argparse.ArgumentParser()
-    p.add_argument('-U', '--username'   , help=help_user           , required=req_user  )
-    p.add_argument('-P', '--password'   , help=help_pass           , required=req_pass  )
-    p.add_argument('-S', '--server'     , help=help_server         , required=req_server)
-    p.add_argument('-T', '--threads'    , help='Total Threads'     , required=True      )
-    p.add_argument('-N', '--nsockets'   , help='Number of Sockets' , required=True      )
-    p.add_argument('-I', '--identity'   , help='Machine pseudonym' , required=False     )
-    p.add_argument(      '--syzygy'     , help='Syzygy WDL'        , required=False     )
-    p.add_argument(      '--fleet'      , help='Fleet Mode'        , action='store_true')
-    p.add_argument(      '--clean'      , help='Force New Client'  , action='store_true')
+    p.add_argument('-U', '--username', help=help_user         , required=req_user  )
+    p.add_argument('-P', '--password', help=help_pass         , required=req_pass  )
+    p.add_argument('-S', '--server'  , help=help_server       , required=req_server)
+    p.add_argument(      '--clean'   , help='Force New Client', action='store_true')
 
-    args = p.parse_args()
+    def custom_help(default_help):
 
+        print (default_help)
+
+        if has_worker():
+            import worker
+            importlib.reload(worker)
+            worker.run_openbench_worker(None)
+
+        exit()
+
+    p.print_help = lambda: custom_help(p.format_help())
+
+    # Replace with ENV variables if needed
+    args, unknown = p.parse_known_args()
     args.username = args.username if args.username else os.environ['OPENBENCH_USERNAME']
     args.password = args.password if args.password else os.environ['OPENBENCH_PASSWORD']
     args.server   = args.server   if args.server   else os.environ['OPENBENCH_SERVER'  ]

--- a/Client/client.py
+++ b/Client/client.py
@@ -67,6 +67,17 @@ def has_worker():
     except ImportError:
         return False
 
+def custom_help(default_help):
+
+    print (default_help)
+
+    if has_worker():
+        import worker
+        importlib.reload(worker)
+        worker.run_openbench_worker(None)
+
+    exit()
+
 def parse_arguments():
 
     # We can use ENV variables for the Username, Passwords, and Servers
@@ -90,17 +101,7 @@ def parse_arguments():
     p.add_argument('-S', '--server'  , help=help_server       , required=req_server)
     p.add_argument(      '--clean'   , help='Force New Client', action='store_true')
 
-    def custom_help(default_help):
-
-        print (default_help)
-
-        if has_worker():
-            import worker
-            importlib.reload(worker)
-            worker.run_openbench_worker(None)
-
-        exit()
-
+    # Override, to possibly print worker.py's help as well as client.py's
     p.print_help = lambda: custom_help(p.format_help())
 
     # Replace with ENV variables if needed

--- a/Client/worker.py
+++ b/Client/worker.py
@@ -100,6 +100,7 @@ class Configuration:
         self.identity    = args.identity if args.identity else 'None'
         self.syzygy_path = args.syzygy   if args.syzygy   else None
         self.fleet       = args.fleet    if args.fleet    else False
+        self.focus       = args.focus    if args.focus    else []
 
     def init_client(self):
 
@@ -976,6 +977,7 @@ def server_configure_worker(config):
         'concurrency'    : config.threads,        # Threads to use to play games
         'sockets'        : config.sockets,        # Cutechess copies, usually equal to Socket count
         'syzygy_max'     : config.syzygy_max,     # Whether or not the machine has Syzygy support
+        'focus'          : config.focus,          # List of engines we have a preference to help
         'client_ver'     : CLIENT_VERSION,        # Version of the Client, which the server may reject
     }
 
@@ -1396,7 +1398,6 @@ def parse_arguments(client_args):
 
     # Add the client args (Username, Password, and Server) to the worker args
     return argparse.Namespace(**{ **vars(client_args), **vars(worker_args) })
-
 
 def run_openbench_worker(client_args):
 

--- a/Client/worker.py
+++ b/Client/worker.py
@@ -50,7 +50,7 @@ from pgn_util import compress_list_of_pgns
 
 ## Basic configuration of the Client. These timeouts can be changed at will
 
-CLIENT_VERSION   = 23 # Client version to send to the Server
+CLIENT_VERSION   = 24 # Client version to send to the Server
 TIMEOUT_HTTP     = 30 # Timeout in seconds for HTTP requests
 TIMEOUT_ERROR    = 10 # Timeout in seconds when any errors are thrown
 TIMEOUT_WORKLOAD = 30 # Timeout in seconds between workload requests
@@ -1375,9 +1375,33 @@ def run_and_parse_cutechess(config, command, cutechess_idx, results_queue, abort
 #                                                                           #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-def run_openbench_worker(args):
+def parse_arguments(client_args):
 
-    config = Configuration(args) # System info, Cmdline arguments, and Workload
+    # Pretty formatting
+    p = argparse.ArgumentParser(
+        formatter_class=lambda prog:
+            argparse.ArgumentDefaultsHelpFormatter(prog, max_help_position=10)
+    )
+
+    # Arguments specific to worker.py
+    p.add_argument('-T', '--threads' , help='Total Threads'           , required=True      )
+    p.add_argument('-N', '--nsockets', help='Number of Sockets'       , required=True      )
+    p.add_argument('-I', '--identity', help='Machine pseudonym'       , required=False     )
+    p.add_argument(      '--syzygy'  , help='Syzygy WDL'              , required=False     )
+    p.add_argument(      '--fleet'   , help='Fleet Mode'              , action='store_true')
+    p.add_argument(      '--focus'   , help='Prefer certain engine(s)', nargs='+'          )
+
+    # Ignore unknown arguments ( from client )
+    worker_args, unknown = p.parse_known_args()
+
+    # Add the client args (Username, Password, and Server) to the worker args
+    return argparse.Namespace(**{ **vars(client_args), **vars(worker_args) })
+
+
+def run_openbench_worker(client_args):
+
+    args   = parse_arguments(client_args) # Merge client.py and worker.py args
+    config = Configuration(args)          # Holds System info, args, and Workload info
 
     setup_error      = '[Note] Unable to establish initial connection with the Server!'
     connection_error = '[Note] Unable to reach the server to request a workload!'

--- a/Config/config.json
+++ b/Config/config.json
@@ -1,7 +1,7 @@
 {
-    "client_version"  : 23,
+    "client_version"  : 24,
     "client_repo_url" : "https://github.com/AndyGrant/OpenBench",
-    "client_repo_ref" : "master",
+    "client_repo_ref" : "focus",
 
     "use_cross_approval"          : false,
     "require_login_to_view"       : false,

--- a/Config/config.json
+++ b/Config/config.json
@@ -1,7 +1,7 @@
 {
     "client_version"  : 24,
     "client_repo_url" : "https://github.com/AndyGrant/OpenBench",
-    "client_repo_ref" : "focus",
+    "client_repo_ref" : "master",
 
     "use_cross_approval"          : false,
     "require_login_to_view"       : false,

--- a/OpenBench/workloads/get_workload.py
+++ b/OpenBench/workloads/get_workload.py
@@ -76,12 +76,6 @@ def select_workload(machine):
     throughput_sum = sum(x['throughput'] for x in worker_dist.values())
     fair_ratio     = thread_sum / throughput_sum
 
-    for id, data in worker_dist.items():
-        print (id, data)
-    print (engine_freq)
-    print (min_ratio)
-    print (fair_ratio)
-
     # Step 6: Repeat the same machine, if we are still at least 75% fair across the board
     if machine.workload in worker_dist.keys():
         if thread_sum > 0 and min_ratio / fair_ratio > 0.75:


### PR DESCRIPTION
Refer to https://github.com/AndyGrant/OpenBench/wiki/Workload-Assignment for a full understanding of the algorithm. 

OpenBench/workloads/get_workload:select_workload() implements this logic step-by-step as indicated on the Wiki. 

These changes introduce a breaking change to client.py, which was supposed to never be done. This was needed, as adding any additional arguments will trigger the ArgParser to error out. This is resolved with the following structure, which could have been implemented initially, with greater forethought.

```python
args, unknown = p.parse_known_args()
```

I did also note that line 146 in client.py will break for forks of OpenBench with name changes. IE @TheBlackPlague's OpenBench fork, although that one is so far master behind it is not an issue at the moment.

