### PR TITLE
Fixes for relative vs absolute file paths when building

### DIFF
--- a/Client/utils.py
+++ b/Client/utils.py
@@ -296,11 +296,16 @@ def download_public_engine(engine, net_path, branch, source, make_path, out_path
         # Prepare the MAKEFILE command
         make_path = os.path.join(src_path, make_path)
         bin_path  = os.path.join(make_path, os.path.basename(out_path))
-        make_cmd  = makefile_command(net_path, make_path, bin_path, compiler)
+        make_cmd  = makefile_command(net_path, make_path, os.path.basename(out_path), compiler)
 
         # Build the engine, which will produce a binary to bin_path, to be moved after
         process     = subprocess.Popen(make_cmd, cwd=make_path, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         comp_output = process.communicate()[0].decode('utf-8')
+
+        # Verify that the compilation subprocess did not exit with errors
+        if process.returncode:
+            message = 'Error during compilation. The logs have been sent to the server'
+            raise OpenBenchBuildFailedException(message, comp_output)
 
         # Move the binary to the proper out_path, account for Windows and cross-drive moves
         if check_for_engine_binary(bin_path):

--- a/Client/worker.py
+++ b/Client/worker.py
@@ -1061,6 +1061,12 @@ def download_engine(config, branch, net_path):
                 engine, net_path, branch_name, source, make_path, out_path, compiler)
 
         except OpenBenchBuildFailedException as error:
+
+            print ('Failed to build %s-%s...\n\nCompiler Output:' % (engine, branch_name))
+            for line in error.logs.split('\n'):
+                print ('> %s' % (line))
+            print ()
+
             ServerReporter.report_build_fail(config, branch, error.logs)
             raise
 


### PR DESCRIPTION
The output binary is saved alongside the makefile initially, and moved after the fact. This was done to account for Windows and cross-drive issues due to temp filesystems. Because we are saving alongside the makefile, we can just use a relative path, ie the basename of the engine binary, to avoid possible issues in some engine build scripts.

Also, check process exitcode instead of just checking for the binary when building 
Also, pretty-print the compiler error, even though it is sent to the server