### PR TITLE
Implement editing of profile repos

### DIFF
--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -229,6 +229,14 @@ def profile_config(request):
         profile.repos.pop(engine, False)
         changes += 'Deleted Engine: %s\n' % (engine)
 
+    for (engine, current_repo) in profile.repos.items():
+        repo_name = request.POST.get('engine-repo-%s' % (engine), '').removesuffix('/')
+        repo = 'https://github.com/%s' % (repo_name)
+
+        if repo != current_repo and repo_name:
+            changes += 'Updated Engine: %s to use %s\n' % (engine, repo)
+            profile.repos[engine] = repo
+
     if changes:
         profile.save()
 


### PR DESCRIPTION
The input fields for engine repos on the profile page aren't read-only, giving the impression that repo links can be changed.
This PR implements the ability to change them. Otherwise, adding the `readonly` attributes would be nice.