### PR TITLE
Add missing focus modifier for textarea

### DIFF
--- a/OpenBench/static/form.css
+++ b/OpenBench/static/form.css
@@ -71,7 +71,7 @@
      padding: 2px 2px;
 }
 
-#content .row input:focus, #content .row select:focus, #content .row textarea {
+#content .row input:focus, #content .row select:focus, #content .row textarea:focus {
     outline: none;
     border-color: var(--color3);
     box-shadow: 0 0 0 2px rgba(77, 144, 254, 0.75);


### PR DESCRIPTION
The textarea form controls have a focus style applied by default, particularly for the SPSA input field. This PR adds the missing focus modifier.