### PR TITLE
Add missing for attributes on some html forms

### DIFF
--- a/Templates/OpenBench/network.html
+++ b/Templates/OpenBench/network.html
@@ -10,27 +10,32 @@
             <div class="col">
 
                 <div class="row">
-                    <label> Hash </label><input readonly value="{{network.sha256}}">
+                    <label for="hash"> Hash </label>
+                    <input id="hash" readonly value="{{network.sha256}}">
                 </div>
 
                 <div class="row">
-                    <label> Engine </label><input readonly value="{{network.engine}}">
+                    <label for="engine"> Engine </label>
+                    <input id="engine" readonly value="{{network.engine}}">
                 </div>
 
                 <div class="row">
-                    <label> Author </label><input readonly value="{{network.author}}">
+                    <label for="author"> Author </label>
+                    <input id="author" readonly value="{{network.author}}">
                 </div>
 
                 <div class="row">
-                    <label> Created </label><input readonly value="{{network.created}}">
+                    <label for="created"> Created </label>
+                    <input id="created" readonly value="{{network.created}}">
                 </div>
 
                 <div class="row">
-                    <label> Name </label><input name='name' value="{{network.name}}">
+                    <label for="name"> Name </label>
+                    <input id="name" name="name" value="{{network.name}}">
                 </div>
 
                 <div class="row">
-                    <label> Default </label>
+                    <label for="default"> Default </label>
                     <select id="default" name="default">
                         {% if network.default %}
                             <option selected value="TRUE"> True </option>
@@ -43,7 +48,7 @@
                 </div>
 
                 <div class="row">
-                    <label> Was Default </label>
+                    <label for="was_default"> Was Default </label>
                     <select id="was_default" name="was_default">
                         {% if network.was_default %}
                             <option selected value="TRUE"> True </option>

--- a/Templates/OpenBench/uploadnet.html
+++ b/Templates/OpenBench/uploadnet.html
@@ -34,13 +34,15 @@
         <div class="form">
              <div class="col">
                 <div class="row">
-                    <label>Name</label><input id="network-name" name="name">
+                    <label for="network-name">Name</label>
+                    <input id="network-name" name="name">
                 </div>
                 <div class="row">
-                    <label>Weights</label><input name="netfile" type="file">
+                    <label for="netfile">Weights</label>
+                    <input id="netfile" name="netfile" type="file">
                 </div>
                 <div class="row">
-                    <label>Engine</label>
+                    <label for="network-engine">Engine</label>
                     <select id="network-engine" name="engine">
                     {% for engine in config.engines %}
                         {% if engine == profile.engine %}


### PR DESCRIPTION
This PR adds missing `for` attributes to associate labels with input controls.