### PR TITLE
Disable restart button for completed tests

### DIFF
--- a/Templates/OpenBench/workload.html
+++ b/Templates/OpenBench/workload.html
@@ -81,9 +81,9 @@
             {% endif %}
 
             <!-- Restart Button: For Approvers or Workload Authors of finished workloads -->
-            {% if workload.finished and profile.approver %}
+            {% if workload.finished and not workload.passed and not workload.failed and profile.approver %}
                 <a class="anchorbutton btn-yellow" href="/{{type|lower}}/{{workload.id}}/RESTART">Restart</a>
-            {% elif workload.finished and profile.user.username == workload.author %}
+            {% elif workload.finished and not workload.passed and not workload.failed and profile.user.username == workload.author %}
                 <a class="anchorbutton btn-yellow" href="/{{type|lower}}/{{workload.id}}/RESTART">Restart</a>
             {% elif workload.finished %}
                 <a class="anchorbutton btn-disabled">Restart</a>


### PR DESCRIPTION
Disable the restart button for finished tests that have been completed (either passed or failed), as continuing a completed test doesn't seem like the intended behavior.