### PR TITLE
Fix syllable abbreviation

### DIFF
--- a/OpenBench/stats.py
+++ b/OpenBench/stats.py
@@ -60,7 +60,7 @@ def PentanomialSPRT(results, elo0, elo1):
     nt0, nt1 = (x / nelo_divided_by_nt for x in (elo0, elo1))
     t0, t1 = nt0 * math.sqrt(2), nt1 * math.sqrt(2)
 
-    # Number of game-pairs, and the PDF of Pntml(0-2) expressed as (0-1)
+    # Number of game-pairs, and the PDF of Ptnml(0-2) expressed as (0-1)
     N = sum(results)
     pdf = [(i / 4, results[i] / N) for i in range(0, 5)]
 

--- a/OpenBench/templatetags/mytags.py
+++ b/OpenBench/templatetags/mytags.py
@@ -61,7 +61,7 @@ def gitDiffLink(test):
 def shortStatBlock(test):
 
     tri_line   = 'Games: %d W: %d L: %d D: %d' % test.as_nwld()
-    penta_line = 'Pntml(0-2): %d, %d, %d, %d, %d' % test.as_penta()
+    penta_line = 'Ptnml(0-2): %d, %d, %d, %d, %d' % test.as_penta()
 
     if test.test_mode == 'SPSA':
         statlines = [


### PR DESCRIPTION
fix misspelling in "pentanomial" syllable abbreviation.

Pntml = pe-n-tano-mi-al ❌ 
Ptnml = pen-ta-no-mi-al ✅ 