### PR TITLE
Limit benching to 60s, before killing engines/threads and raising an exception

### DIFF
--- a/Client/genfens.py
+++ b/Client/genfens.py
@@ -21,10 +21,10 @@
 # The sole purpose of this module is to invoke create_genfens_opening_book().
 #
 # This will execute engines with commands like the following:
-#   ./engine "genfens N seed S book <None|Books/book.epd> <?exta>" "quit"
+#   ./engine "genfens N seed S book <None|Books/book.epd> <?extra>" "quit"
 #
 # This work is split over many engines. If a workload requires 1024 openings,
-# and there are 16 threads, then each thread will generate 128 openings. The
+# and there are 16 threads, then each thread will generate 64 openings. The
 # openings are saved to Books/openbench.genfens.epd
 #
 # create_genfens_opening_book() may raise utils.OpenBenchFailedGenfensException.

--- a/Scripts/bench_all.py
+++ b/Scripts/bench_all.py
@@ -160,5 +160,9 @@ if __name__ == '__main__':
         private_net = configs[engine]['private'] and configs[engine].get('network')
         net_path    = os.path.join('Networks', configs[engine]['network']['sha']) if private_net else None
 
-        nps, nodes = run_benchmark(bin_path, net_path, private_net, args.threads, args.sets)
-        print (print_format % (engine, nps, nodes, nodes / max(1e-6, nps)))
+        try:
+            nps, nodes = run_benchmark(bin_path, net_path, private_net, args.threads, args.sets)
+            print (print_format % (engine, nps, nodes, nodes / max(1e-6, nps)))
+
+        except OpenBenchBadBenchException as error:
+            print ('%s: %s' % (engine, error))


### PR DESCRIPTION
Adds a fourth posssible OpenBenchBadBenchException exception during benching, for exceeding the max bench duration. This ensures that engines that infinitely stall, do not also lock up OpenBench clients.

Additionally, make sure to clean up possible zombie processes that existed even in the case of a proper bench. 