### PR TITLE
Use soft nodes when doing fixed node tests for datagen.

### DIFF
--- a/Engines/Torch.json
+++ b/Engines/Torch.json
@@ -147,9 +147,9 @@
             "workload_size" : 64
         },
 
-        "57.5k Nodes" : {
+        "36k (Soft) Nodes" : {
             "both_options"      : "Threads=1 Hash=16 Minimal=true Normalize=false UseSoftNodes=true",
-            "both_time_control" : "N=57500"
+            "both_time_control" : "N=36000"
         }
     }
 }

--- a/Engines/Torch.json
+++ b/Engines/Torch.json
@@ -148,7 +148,7 @@
         },
 
         "57.5k Nodes" : {
-            "both_options"      : "Threads=1 Hash=16 Minimal=true Normalize=false",
+            "both_options"      : "Threads=1 Hash=16 Minimal=true Normalize=false UseSoftNodes=true",
             "both_time_control" : "N=57500"
         }
     }


### PR DESCRIPTION
Not sure I did that correctly.

Use soft nodes when doing 57.5 node tests for datagen.