### PR TITLE
fix: add `scipy==1.9.0` to server's `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==4.2.1
 django-htmlmin==0.11.0
 requests
-scipy
+scipy==1.9.0


### PR DESCRIPTION
scipy 1.9.0 is the lowest version that allows you to call `scipy.optimize.brentq`, which is required in [`OpenBench/stats.py`](https://github.com/AndyGrant/OpenBench/blob/8216eec36d4eb2a40f72788c130843475da79fbd/OpenBench/stats.py#L117)

Context:
When attempting to set up an OpenBench server on a machine that had an outdated version of scipy (`1.7.3`), I encountered errors whenever clients would try to upload test results to the server.
After debugging, it was discovered that the scipy version was too old, and needed to be updated.

Evidence:
```
$ pip3 freeze | grep scipy
scipy==1.9.0
$ python3
Python 3.10.15 (main, Oct  3 2024, 07:27:34) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import scipy
>>> print (scipy.optimize.brentq)
<function brentq at 0x79f8f5d470a0>
```

```
$ pip3 freeze | grep scipy
scipy==1.8.1
$ python3
Python 3.10.15 (main, Oct  3 2024, 07:27:34) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import scipy
>>> print (scipy.optimize.brentq)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'scipy' has no attribute 'optimize'
```

There is no version between [`1.8.1`](https://docs.scipy.org/doc/scipy/release/1.8.1-notes.html) and [`1.9.0`](https://docs.scipy.org/doc/scipy/release/1.9.0-notes.html).

The full conversation between Andrew and I regarding this bug can be found starting with [this discord message](https://discord.com/channels/759496923324874762/1157627941635764314/1293692891285295135)

Upon investigation, scipy `1.9.0` appears to be the minimum version to support the required function in the context it is being used in.