### PR TITLE
remove scipy version requirement

### DIFF
--- a/OpenBench/stats.py
+++ b/OpenBench/stats.py
@@ -28,6 +28,7 @@
 
 import math
 import scipy
+from scipy import optimize
 
 def TrinomialSPRT(results, elo0, elo1):
 
@@ -114,7 +115,7 @@ def secular(pdf):
     def f(x):
         return sum([pi * ai / (1 + x * ai) for ai, pi in pdf])
 
-    x, res = scipy.optimize.brentq(
+    x, res = optimize.brentq(
         f, l + epsilon, u - epsilon, full_output=True, disp=False
     )
     assert res.converged

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==4.2.1
 django-htmlmin==0.11.0
 requests
-scipy==1.9.0
+scipy


### PR DESCRIPTION
versions long before 1.9.0 still has optimize, the problem is it needs to be imported seperately https://github.com/numenta/htmresearch/pull/704

this is the specific scipy commit https://github.com/scipy/scipy/pull/15230