### PR TITLE
feat: support for xboard

### DIFF
--- a/Client/worker.py
+++ b/Client/worker.py
@@ -452,6 +452,7 @@ class Cutechess:
         network = config.workload['test'][branch]['network']
         private = config.workload['test'][branch]['private']
         engine  = config.workload['test'][branch]['engine']
+        protocol= config.workload['test'][branch]['protocol']
         syzygy  = config.workload['test']['syzygy_wdl']
 
         # Human-readable name, and scale the time control
@@ -478,7 +479,7 @@ class Cutechess:
 
         # Join options together in the Cutechess format
         options = ' option.'.join([''] + re.findall(r'"[^"]*"|\S+', options))
-        return '-engine dir=Engines/ cmd=./%s proto=uci %s%s name=%s-%s' % (command, control, options, engine, branch)
+        return '-engine dir=Engines/ cmd=./%s proto=%s %s%s name=%s-%s' % (command, protocol, control, options, engine, branch)
 
     @staticmethod
     def pgnout_settings(config, timestamp, cutechess_idx):

--- a/OpenBench/config.py
+++ b/OpenBench/config.py
@@ -62,6 +62,10 @@ def load_engine_config(engine_name):
         with open(os.path.join(PROJECT_PATH, 'Engines', '%s.json' % (engine_name))) as fin:
             conf = json.load(fin)
 
+        # Legacy- default to UCI protocol if none provided.
+        if 'protocols' not in conf:
+            conf['protocols'] = ['uci']
+
         verify_engine_basics(conf)
         verify_engine_build(engine_name, conf)
 
@@ -107,6 +111,7 @@ def verify_engine_basics(conf):
     assert type(conf.get('nps')) == int and conf['nps'] > 0
     assert type(conf.get('source')) == str
     assert type(conf.get('build')) == dict
+    assert type(conf.get('protocols')) == list
 
 def verify_engine_build(engine_name, conf):
 
@@ -140,12 +145,14 @@ def verify_engine_test_preset(test_preset):
         'dev_network',
         'dev_options',
         'dev_time_control',
+        'dev_protocol',
 
         'base_branch',
         'base_bench',
         'base_network',
         'base_options',
         'base_time_control',
+        'base_protocol',
 
         'test_bounds',
         'test_confidence',
@@ -176,6 +183,7 @@ def verify_engine_tune_preset(tune_preset):
         'dev_network',
         'dev_options',
         'dev_time_control',
+        'dev_protocol',
 
         'spsa_reporting_type',
         'spsa_distribution_type',
@@ -215,12 +223,15 @@ def verify_engine_datagen_preset(datagen_preset):
         'dev_network',
         'dev_options',
         'dev_time_control',
+        'dev_protocol',
 
         'base_branch',
         'base_bench',
         'base_network',
         'base_options',
         'base_time_control',
+        'base_protocol',
+
 
         'book_name',
         'upload_pgns',

--- a/OpenBench/models.py
+++ b/OpenBench/models.py
@@ -29,6 +29,7 @@ class Engine(Model):
     source   = CharField(max_length=1024)
     sha      = CharField(max_length=64)
     bench    = IntegerField(default=0)
+    protocols= JSONField(default=list)
 
     def __str__(self):
         return '{0} ({1})'.format(self.name, self.bench)
@@ -105,6 +106,7 @@ class Test(Model):
     dev_network      = CharField(max_length=256, blank=True)
     dev_netname      = CharField(max_length=256, blank=True)
     dev_time_control = CharField(max_length=32)
+    dev_protocol     = CharField(max_length=32, default='uci')
 
     # Base Engine, and all of its settings
     base              = ForeignKey('Engine', PROTECT, related_name='base')
@@ -114,6 +116,7 @@ class Test(Model):
     base_network      = CharField(max_length=256, blank=True)
     base_netname      = CharField(max_length=256, blank=True)
     base_time_control = CharField(max_length=32)
+    base_protocol     = CharField(max_length=32, default='uci')
 
     # Changable Test Parameters
     workload_size = IntegerField(default=32)

--- a/OpenBench/static/create_workload.js
+++ b/OpenBench/static/create_workload.js
@@ -36,6 +36,27 @@ function create_network_options(field_id, engine) {
     }
 }
 
+function create_protocol_options(field_id, engine) {
+
+    var has_default      = false;
+    var protocol_options = document.getElementById(field_id);
+
+    // Delete all existing Protocols
+    while (protocol_options.length)
+        protocol_options.remove(0);
+
+    // Add each Protocol that matches the given engine
+    for (const protocol of config.engines[engine].protocols) {
+
+        var opt      = document.createElement('option');
+        opt.text     = protocol;
+        opt.selected = false;
+        protocol_options.add(opt)
+
+        has_default = has_default || protocol.default;
+    }
+}
+
 function create_preset_buttons(engine, workload_type) {
 
     // Clear out all of the existing buttons
@@ -123,6 +144,7 @@ function set_engine(engine, target) {
     document.getElementById(target + '_repo'  ).value = repos[engine] || config.engines[engine].source
 
     create_network_options(target + '_network', engine);
+    create_protocol_options(target + '_protocol', engine);
 }
 
 function set_option(option_name, option_value) {

--- a/OpenBench/workloads/create_workload.py
+++ b/OpenBench/workloads/create_workload.py
@@ -122,6 +122,7 @@ def create_new_test(request):
     test.dev_options       = request.POST['dev_options']
     test.dev_network       = request.POST['dev_network']
     test.dev_time_control  = OpenBench.utils.TimeControl.parse(request.POST['dev_time_control'])
+    test.dev_protocol     = request.POST['dev_protocol']
 
     test.base              = get_engine(*base_ingo)
     test.base_repo         = request.POST['base_repo']
@@ -129,6 +130,7 @@ def create_new_test(request):
     test.base_options      = request.POST['base_options']
     test.base_network      = request.POST['base_network']
     test.base_time_control = OpenBench.utils.TimeControl.parse(request.POST['base_time_control'])
+    test.base_protocol     = request.POST['base_protocol']
 
     test.workload_size     = int(request.POST['workload_size'])
     test.priority          = int(request.POST['priority'])
@@ -187,6 +189,7 @@ def create_new_tune(request):
     test.dev_options      = test.base_options      = request.POST['dev_options']
     test.dev_network      = test.base_network      = request.POST['dev_network']
     test.dev_time_control = test.base_time_control = OpenBench.utils.TimeControl.parse(request.POST['dev_time_control'])
+    test.dev_protocol     = test.base_network      = request.POST['dev_protocol']
 
     test.workload_size    = int(request.POST['spsa_pairs_per'])
     test.priority         = int(request.POST['priority'])
@@ -235,6 +238,7 @@ def create_new_datagen(request):
     test.dev_options       = request.POST['dev_options']
     test.dev_network       = request.POST['dev_network']
     test.dev_time_control  = OpenBench.utils.TimeControl.parse(request.POST['dev_time_control'])
+    test.dev_protocol      = request.POST['dev_protocol']
 
     test.base              = get_engine(*base_ingo)
     test.base_repo         = request.POST['base_repo']
@@ -242,6 +246,7 @@ def create_new_datagen(request):
     test.base_options      = request.POST['base_options']
     test.base_network      = request.POST['base_network']
     test.base_time_control = OpenBench.utils.TimeControl.parse(request.POST['base_time_control'])
+    test.base_protocol     = request.POST['base_protocol']
 
     test.max_games         = int(request.POST['datagen_max_games'])
     test.genfens_args      = request.POST['datagen_custom_genfens']

--- a/OpenBench/workloads/get_workload.py
+++ b/OpenBench/workloads/get_workload.py
@@ -218,6 +218,7 @@ def workload_to_dictionary(test, result, machine):
         'nps'          : OPENBENCH_CONFIG['engines'][test.dev_engine]['nps'],
         'build'        : OPENBENCH_CONFIG['engines'][test.dev_engine]['build'],
         'private'      : OPENBENCH_CONFIG['engines'][test.dev_engine]['private'],
+        'protocol'     : test.dev_protocol,
     }
 
     workload['test']['base'] = {
@@ -234,6 +235,7 @@ def workload_to_dictionary(test, result, machine):
         'nps'          : OPENBENCH_CONFIG['engines'][test.base_engine]['nps'],
         'build'        : OPENBENCH_CONFIG['engines'][test.base_engine]['build'],
         'private'      : OPENBENCH_CONFIG['engines'][test.base_engine]['private'],
+        'protocol'     : test.base_protocol,
     }
 
     workload['distribution']   = game_distribution(test, machine)

--- a/OpenBench/workloads/verify_workload.py
+++ b/OpenBench/workloads/verify_workload.py
@@ -80,6 +80,7 @@ def verify_test_creation(errors, request):
         (verify_options        , 'dev_options', 'Threads', 'Dev Options'),
         (verify_options        , 'dev_options', 'Hash', 'Dev Options'),
         (verify_time_control   , 'dev_time_control', 'Dev Time Control'),
+        (verify_protocol       , 'dev_protocol', 'Dev Protocol'),
 
         # Verify everything about the Base Engine
         (verify_configuration  , 'base_engine', 'Base Engine', 'engines'),
@@ -88,6 +89,7 @@ def verify_test_creation(errors, request):
         (verify_options        , 'base_options', 'Threads', 'Base Options'),
         (verify_options        , 'base_options', 'Hash', 'Base Options'),
         (verify_time_control   , 'base_time_control', 'Base Time Control'),
+        (verify_protocol       , 'base_protocol', 'Base Protocol'),
 
         # Verify everything about the Test Settings
         (verify_configuration  , 'book_name', 'Book', 'books'),
@@ -231,6 +233,10 @@ def verify_configuration(errors, request, field, field_name, parent):
 def verify_time_control(errors, request, field, field_name):
     try: OpenBench.utils.TimeControl.parse(request.POST[field])
     except: errors.append('{0} is not parsable'.format(field_name))
+
+def verify_protocol(errors, request, field, field_name):
+    try: assert request.POST[field].lower() == 'uci' or request.POST[field].lower() == 'xboard'
+    except: errors.append('{0} is not a valid protocol'.format(field_name))
 
 def verify_win_adj(errors, request, field):
     try:

--- a/Templates/OpenBench/create_workload.html
+++ b/Templates/OpenBench/create_workload.html
@@ -8,7 +8,8 @@
     {{ networks|json_script:"json-networks" }}
     {{ profile.repos|json_script:"json-repos" }}
 
-    <script src="{% static 'create_workload.js' %}?{{ static_version }}"></script>
+    <!-- <script src="{% static 'create_workload.js' %}?{{ static_version }}"></script> -->
+    <script src="{% static 'create_workload.js' %}?"></script>
     <script src="{% static 'default_text.js' %}?{{ static_version }}"></script>
 
     <script>
@@ -77,6 +78,9 @@
                 <div class="row">
                     <label for="dev_time_control"> {{dev_text}} Time </label> <input id="dev_time_control" name="dev_time_control">
                 </div>
+                <div class="row">
+                    <label for="dev_protocol"> {{dev_text}} Protocol </label> <select id="dev_protocol" name="dev_protocol"></select>
+                </div>
 
                 {% if workload == "TEST" or workload == "DATAGEN" %}
 
@@ -96,6 +100,9 @@
                     </div>
                     <div class="row">
                         <label for="base_time_control" > Base Time </label> <input id="base_time_control" name="base_time_control">
+                    </div>
+                    <div class="row">
+                        <label for="base_protocol" > Base Protocol </label> <select id="base_protocol" name="base_protocol"></select>
                     </div>
 
                 {% elif workload == "TUNE" %}

--- a/Templates/OpenBench/workload.html
+++ b/Templates/OpenBench/workload.html
@@ -25,6 +25,7 @@
             <tr><td class="td-label">{{dev_text}} Network</td><td><a href="{{workload|network_download_link:'dev'}}">{{workload.dev_netname}}</td></tr>
             <tr><td class="td-label">{{dev_text}} Options</td><td>{{workload.dev_options}}</td></tr>
             <tr><td class="td-label">{{dev_text}} Time</td><td>{{workload.dev_time_control}}</td></tr>
+            <tr><td class="td-label">{{dev_text}} Protocol</td><td>{{workload.dev_protocol}}</td></tr>
 
             <!-- All of the Base Engine information, which only exists for TESTs -->
             {% if type == "TEST" or type == "DATAGEN" %}
@@ -35,6 +36,7 @@
                 <tr><td class="td-label">Base Network</td><td><a href="{{workload|network_download_link:'base'}}">{{workload.base_netname}}</td></tr>
                 <tr><td class="td-label">Base Options</td><td>{{workload.base_options}}</td></tr>
                 <tr><td class="td-label">Base Time</td><td>{{workload.base_time_control}}</td></tr>
+                <tr><td class="td-label">Base Protocol</td><td>{{workload.base_protocol}}</td></tr>
             {% endif %}
 
             {% if workload|book_download_link %}


### PR DESCRIPTION
Adds ability to select `xboard` as a communication protocol for engines that support it.

---
# Problem
[`cutechess-ob`](https://github.com/AndyGrant/OpenBench/blob/master/Client/cutechess-ob) has a command line option to specify a communication protocol when testing engines:
```
 proto=PROTOCOL        Set the chess protocol to PROTOCOL, which can be one of:
                        'xboard': The Xboard/Winboard/CECP protocol
                        'uci': The Universal Chess Interface
```
At the time of writing, `proto=uci` is [hardcoded into OpenBench](https://github.com/AndyGrant/OpenBench/blob/master/Client/worker.py#L481). This PR changes that, and adds necessary fields elsewhere to allow users to specify which protocol they'd like to test with.


# Solution
I modified `worker.py` to include a `protocol` variable when running `cutechess-ob` that is fetched from the workload. I added a `dev_protocol` and `base_protocol` field onto all test models that I could find. I also updated the UI files to display a drop-down of the protocols support by the selected engine(s). All workload creation/verification files have been updated to support this new `protocol` field, as well.

To specify an engine's supported protocols, you can add a `protocols` field to the engine's JSON config at `Engines/<engine>.json`. The value of `protocols` is expected to be a list of values, containing `uci`, or `xboard` (or both). To provide backwards compatibility, [config.py](https://github.com/AndyGrant/OpenBench/compare/master...dannyhammer:OpenBench:xboard-support?expand=1#diff-01bb0fc015419b125dea141aaaeb635dd06a6deb0edb45b912dedd1aca3d71b6R65) will set a default value of `'protocols': ['uci']` if `protocols` was not found when parsing an engine's JSON config.


# Examples
[Here](https://pyronomy.pythonanywhere.com/test/185/) is an example test ran between a UCI engine and an Xboard engine. Note that you can see the values for `dev_protocol` and `base_protocol`.

Here is an image of the drop-down menu to select a protocol when creating a test. The engine here is [Yukari](https://github.com/yukarichess/yukari), which (presently) only supports Xboard.
![image](https://github.com/user-attachments/assets/c7e74add-3907-42b5-b8d7-e7e564ba909b)

[Here](https://github.com/dannyhammer/OpenBench/blob/master/Engines/Yukari.json) is Yukari's JSON config, with the the value of the `"protocols"` set to `["xboard"]`. In this same repository is the [config for Toad](https://github.com/dannyhammer/OpenBench/blob/master/Engines/Toad.json) , which is the other engine used in the example test above. Note the lack of a `"protocols"` field, and yet it properly defaulted to `uci`.

# Comments

`cutechess-ob` doesn't support any other protocols, so I don't see any extensibility issues with this implementation.

The protocol verification in [`verify_workload.py`](https://github.com/dannyhammer/OpenBench/blob/master/Engines/Toad.json#L5) is... not as clean as I would like. Open to suggestions on how better to implement that.

The legacy support in [`config.py`](https://github.com/dannyhammer/OpenBench/blob/master/Engines/Toad.json#L5) is also less-than-ideal, but I'm not sure of a nicer way of providing legacy support. Again, I'm open to suggestions.