### PR TITLE
fix: updated paths in create_workload.py

### DIFF
--- a/OpenBench/workloads/create_workload.py
+++ b/OpenBench/workloads/create_workload.py
@@ -85,7 +85,7 @@ def create_workload(request, workload_type):
         workload, errors = create_new_datagen(request)
 
     if errors != [] and errors != None:
-        paths = { 'TEST' : '/newTest/', 'TUNE' : '/newTune/', 'DATAGEN' : '/newDatagen/' }
+        paths = { 'TEST' : '/test/new/', 'TUNE' : '/tune/new/', 'DATAGEN' : '/datagen/new/' }
         return OpenBench.views.redirect(request, paths[workload_type], error='\n'.join(errors))
 
     if warning := OpenBench.utils.branch_is_out_of_date(workload):


### PR DESCRIPTION
Updated the paths in `create_workload()` when a workload creation causes an error.

Didn't see any other instances of `newTest`, `newTune`, or `newDatagen` that needed to be changed.