### PR TITLE
fix: updated `MODIFY` path in `workload.html`

### DIFF
--- a/Templates/OpenBench/workload.html
+++ b/Templates/OpenBench/workload.html
@@ -154,7 +154,7 @@
         {% endif %}
 
         <!-- Forum to modify the Priority, Throughput, or (Tests only) Workload Size -->
-        <form method="POST" action="/{{type|lower}}/{{workload.id}}/MODIFY">
+        <form method="POST" action="/{{type|lower}}/{{workload.id}}/MODIFY/">
             {% csrf_token %}
             <div class="form">
                 <div class="col-full">


### PR DESCRIPTION
Currently, clicking the "Modify" button on a workload will break the page, and not actually modify anything. Example screenshot below:

![Screenshot_20241224_200928](https://github.com/user-attachments/assets/151c69a5-9ee8-47ba-82b1-933dd722e81e)


Credit to Lofty for discovering the fix. I'm just patching it in here. Do with this what you will.