### PR TITLE
Update Stash config

### DIFF
--- a/Engines/Stash.json
+++ b/Engines/Stash.json
@@ -6,7 +6,7 @@
     "build" : {
         "path"      : "src",
         "compilers" : ["gcc", "clang"],
-        "cpuflags"  : ["POPCNT"],
+        "cpuflags"  : [],
         "systems"   : ["Windows", "Linux"]
     },
 
@@ -14,7 +14,7 @@
 
         "default" : {
             "base_branch"     : "master",
-            "book_name"       : "4moves_noob.epd",
+            "book_name"       : "UHO_4060_v2.epd",
             "test_bounds"     : "[0.00, 5.00]",
             "test_confidence" : "[0.05, 0.05]",
             "win_adj"         : "movecount=3 score=400",
@@ -33,6 +33,20 @@
             "workload_size"     : 8
         },
 
+        "Nonreg STC" : {
+            "both_options"      : "Threads=1 Hash=16",
+            "both_time_control" : "8.0+0.08",
+            "workload_size"     : 32,
+            "test_bounds"       : "[-4.00, 1.00]"
+        },
+
+        "Nonreg LTC" : {
+            "both_options"      : "Threads=1 Hash=64",
+            "both_time_control" : "40.0+0.4",
+            "workload_size"     : 8,
+            "test_bounds"       : "[-4.00, 1.00]"
+        },
+
         "SMP STC" : {
             "both_options"      : "Threads=8 Hash=64",
             "both_time_control" : "5.0+0.05",
@@ -49,23 +63,33 @@
     "tune_presets" : {
 
         "default" : {
-            "book_name" : "4moves_noob.epd",
+            "book_name" : "UHO_4060_v2.epd",
             "win_adj"   : "movecount=3 score=400",
             "draw_adj"  : "movenumber=40 movecount=8 score=10"
+        },
+
+        "STC" : {
+            "both_options"      : "Threads=1 Hash=16",
+            "both_time_control" : "8.0+0.08"
+        },
+
+        "LTC" : {
+            "both_options"      : "Threads=1 Hash=64",
+            "both_time_control" : "40.0+0.4"
         }
     },
 
     "datagen_presets" : {
 
         "default" : {
-            "win_adj"       : "None",
-            "draw_adj"      : "None",
-            "workload_size" : 128
+            "win_adj"       : "movecount=3 score=1410",
+            "draw_adj"      : "movenumber=40 movecount=8 score=15",
+            "workload_size" : 256
         },
 
-        "40k Nodes" : {
-            "both_options"      : "Threads=1 Hash=16",
-            "both_time_control" : "N=40000"
+        "16k Nodes" : {
+            "both_options"      : "Threads=1 Hash=1 NormalizeScore=false",
+            "both_time_control" : "N=16000"
         }
     }
 }


### PR DESCRIPTION
Change the default book to be used from v37 onwards, and add some presets for non-regression tests as well as tunes.
Also change the default parameters for datagen runs, and remove POPCNT from the cpuflags config as it is not strictly required for building Stash.