### PR TITLE
Fix safari date display on mobile

### DIFF
--- a/Templates/OpenBench/base.html
+++ b/Templates/OpenBench/base.html
@@ -37,8 +37,8 @@
                     };
 
                     for (var i = 0; i < timestamps.length; i++) {
-                        var date = new Date(1000 * timestamps[i].innerHTML);
-                        timestamps[i].innerHTML = date.toLocaleString(undefined, options);
+                        var date = new Date(1000 * timestamps[i].textContent);
+                        timestamps[i].textContent = date.toLocaleString(undefined, options);
                     }
                 }
 
@@ -51,8 +51,8 @@
                     };
 
                     for (var i = 0; i < datestamps.length; i++) {
-                        var date = new Date(1000 * datestamps[i].innerHTML);
-                        datestamps[i].innerHTML = date.toLocaleString(undefined, options);
+                        var date = new Date(1000 * datestamps[i].textContent);
+                        datestamps[i].textContent = date.toLocaleString(undefined, options);
                     }
                 }
 


### PR DESCRIPTION
Safari on mobile automatically formats Unix time stamp to links to phone numbers. E.g. `1746223790` to `<a href="tel:1746223790">1746223790</a>`. Since `innerHTML` returns the entire HTML content contained within the element, this breaks the date calculation code. Using `textContent`, which ignores html tags, fixes this issue.