### PR TITLE
decode bench output as utf8 instead of ascii

### DIFF
--- a/Client/bench.py
+++ b/Client/bench.py
@@ -46,7 +46,7 @@ MAX_BENCH_TIME_SECONDS = 60
 def parse_stream_output(stream):
 
     nps = bench = None # Search through output Stream
-    for line in stream.decode('ascii').strip().split('\n')[::-1]:
+    for line in stream.decode('utf-8').strip().split('\n')[::-1]:
 
         # Convert non alpha-numerics to spaces
         line = re.sub(r'[^a-zA-Z0-9 ]+', ' ', line)


### PR DESCRIPTION
Previously, a really opaque error was produced when non-ascii characters were present. However, since we explicitly replace non alpha-numeric characters, there is no need to fail on this.