### PR TITLE
Adjust Halogen reference nps

### DIFF
--- a/Engines/Halogen.json
+++ b/Engines/Halogen.json
@@ -1,6 +1,6 @@
 {
     "private" : false,
-    "nps"     : 1893000,
+    "nps"     : 1000000,
     "source"  : "https://github.com/KierenP/Halogen",
 
     "build" : {


### PR DESCRIPTION
Some reference values:
`AMD EPYC 7B13` -> 1.1mnps
`AMD Ryzen 9 9950X 16-Core Processor` -> 1.63mnps