### PR TITLE
Ensure process termination on Linux

### DIFF
--- a/Client/utils.py
+++ b/Client/utils.py
@@ -96,7 +96,7 @@ def kill_process_by_name(process_name):
     process_name = os.path.basename(process_name)
 
     if IS_LINUX:
-        subprocess.run(['pkill', '-f', process_name])
+        subprocess.run(['pkill', '-KILL', '-f', process_name])
 
     if IS_WINDOWS:
         subprocess.run(['taskkill', '/f', '/im', process_name])


### PR DESCRIPTION
A forceful termination is already done on Windows.
Here we use `SIGKILL` instead of `SIGTERM` to ensure process termination on Linux.