### PR TITLE
Display workload title for better UX

### DIFF
--- a/Templates/OpenBench/base.html
+++ b/Templates/OpenBench/base.html
@@ -18,7 +18,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Courier+Prime&display=swap" rel="stylesheet">
 
-        <title>OpenBench</title>
+        <title>{% block title %}OpenBench{% endblock %}</title>
 
         {% block scripts %}
         {% endblock %}

--- a/Templates/OpenBench/workload.html
+++ b/Templates/OpenBench/workload.html
@@ -1,5 +1,7 @@
 {% extends "OpenBench/base.html" %}
 
+{% block title %}{{ workload }}{% endblock %}
+
 {% load mytags %}
 {% load static %}
 


### PR DESCRIPTION
Display workload name in the title bar

<img width="495" height="88" alt="image" src="https://github.com/user-attachments/assets/a632fe22-aff7-4ffa-8fd9-cf5fdb341023" />
