### PR TITLE
Add dividers for priority of tests

### DIFF
--- a/OpenBench/utils.py
+++ b/OpenBench/utils.py
@@ -172,6 +172,14 @@ def get_active_tests():
     t = t.exclude(deleted=True)
     return t.order_by('-priority', '-currentllr')
 
+def group_active_tests_by_priority(active):
+    grouped = []
+    for test in active:
+        if len(grouped) == 0 or grouped[-1]['priority'] != test.priority:
+            grouped.append({ 'priority' : test.priority, 'tests' : [] })
+        grouped[-1]['tests'].append(test)
+    return grouped
+
 def get_completed_tests():
     t = Test.objects.filter(finished=True)
     t = t.exclude(deleted=True)

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -274,7 +274,7 @@ def index(request, page=1):
 
     data = {
         'pending'   : pending,
-        'active'    : active,
+        'active'    : OpenBench.utils.group_active_tests_by_priority(active),
         'completed' : completed[start:end],
         'awaiting'  : awaiting,
         'paging'    : paging,
@@ -294,7 +294,7 @@ def user(request, username, page=1):
 
     data = {
         'pending'   : pending,
-        'active'    : active,
+        'active'    : OpenBench.utils.group_active_tests_by_priority(active),
         'completed' : completed[start:end],
         'awaiting'  : awaiting,
         'paging'    : paging,

--- a/Templates/OpenBench/index.html
+++ b/Templates/OpenBench/index.html
@@ -34,19 +34,13 @@
             <!-- Currently Running tests (Waiting to be completed) -->
             {% if active %}
                 <tr class="table-header"><th colspan='6'>Active {{status}}</th></tr>
-                {% for test in active %}
-
-                    <!-- Add two empty rows ( for the colouring scheme ) when changing prio -->
-                    {% with prev_test=active|previous:forloop.counter0 %}
-                        {% if prev_test and prev_test.priority != test.priority %}
-                            <tr class="table-spacer-small"><th colspan='6'></th></tr>
-                            <tr class="table-spacer-small"><th colspan='6'></th></tr>
-                        {% endif %}
-                    {% endwith %}
-
-                    <tr>
-                        {% include "OpenBench/Blocks/testsummary.html" %}
-                    </tr>
+                {% for group in active %}
+                    <tr class="table-small-header"><th colspan='6'>Priority {{group.priority}}</th></tr>
+                    {% for test in group.tests %}
+                        <tr>
+                            {% include "OpenBench/Blocks/testsummary.html" %}
+                        </tr>
+                    {% endfor %}
                 {% endfor %}
                 <tr class="table-spacer"><th colspan='6'></th></tr>
             {% endif %}


### PR DESCRIPTION
Show each group's priority in the section header.

<img width="958" height="398" alt="image" src="https://github.com/user-attachments/assets/5a63b778-3ce4-43fb-8ed5-135e201fa89e" />