### PR TITLE
Add z-index to sidebar for proper stacking

### DIFF
--- a/OpenBench/static/style.css
+++ b/OpenBench/static/style.css
@@ -31,6 +31,7 @@ body, html, main{
 #sidebar {
     padding: 60px 16px 16px 16px;
     flex-basis: calc(min(300px, max(200px, 10%)));
+    z-index: 5;
 }
 
 #sidebar-toggle {


### PR DESCRIPTION
Adding z-index fixes cases where some other page elements (i.e. network stars) stack above the sidebar on mobile as displayed below.

<img width="355" height="768" alt="image" src="https://github.com/user-attachments/assets/21b4ae85-c8d6-4e7a-b44c-53545cdac2f3" />
