### PR TITLE
Try to ensure pkill python3 / pkill gunicorn are always graceful

### DIFF
--- a/OpenBench/apps.py
+++ b/OpenBench/apps.py
@@ -19,9 +19,9 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 import atexit
-import os
-import threading
+import pathlib
 import platform
+import threading
 
 import django.apps
 
@@ -92,7 +92,7 @@ class OpenBenchConfig(django.apps.AppConfig):
             self.artifact_watcher.start()
             self.pgn_watcher.start()
 
-            # Ensure we cleanup upon exit
+            # We expect a nice sys.exit(0) to allow our atexit to execute
             atexit.register(self.shutdown)
 
     def shutdown(self):
@@ -110,4 +110,4 @@ class OpenBenchConfig(django.apps.AppConfig):
         # Cleanup Lockfile if we hold it
         if self.lockfile:
             self.lockfile.close()
-            os.remove(LOCKFILE_PATH)
+            pathlib.Path(LOCKFILE_PATH).unlink(missing_ok=True)

--- a/OpenBench/pgn_watcher.py
+++ b/OpenBench/pgn_watcher.py
@@ -60,6 +60,8 @@ class PGNWatcher(threading.Thread):
             pgn.save()
 
     def run(self):
+
+        # self.stop_event is set during a graceful shutdown via apps.py:shutdown()
         while not self.stop_event.wait(timeout=15):
 
             try: # Never exit on errors, to keep the watcher alive

--- a/OpenSite/wsgi.py
+++ b/OpenSite/wsgi.py
@@ -8,9 +8,43 @@ https://docs.djangoproject.com/en/2.0/howto/deployment/wsgi/
 """
 
 import os
+import signal
+import sys
+import threading
 
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "OpenSite.settings")
+
+# OpenBench.apps registers an atexit shutdown() that gracefully stops the PGN
+# and Artifact watcher threads -- joining them so any in-flight tar write is
+# allowed to finish. atexit only runs on a clean interpreter exit, not on a
+# bare SIGTERM, so we install a SIGTERM handler that turns the kill signal into
+# a clean sys.exit() and thereby triggers that atexit shutdown().
+#
+# signal.signal() may only be called from the main thread, and ready() (where
+# the watchers are spawned) is not guaranteed to run there. So the handler is
+# installed at the two process entry points instead, each of which IS the main
+# thread of its own process:
+#
+#     manage.py        -> the entry point for `runserver`        (the runserver case)
+#     OpenSite/wsgi.py -> the module gunicorn imports per worker (here)
+#
+# Whichever entry point starts the process installs the handler; the other
+# no-ops for that run (under runserver, wsgi.py is imported off the main thread
+# and skips itself -- hence the main-thread guard below). Keep this block and
+# the handler in sync across both files.
+#
+# Ignore any further SIGTERMs so the atexit shutdown runs to completion. A
+# `pkill -TERM gunicorn` hits each worker directly AND the arbiter, which
+# then broadcasts a second SIGTERM to every worker; without this the second
+# signal would re-enter here and abort the shutdown partway through.
+
+def graceful_exit_on_sigterm(*args):
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    sys.exit(0)
+
+if threading.current_thread() is threading.main_thread():
+    signal.signal(signal.SIGTERM, graceful_exit_on_sigterm)
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -1,9 +1,39 @@
 #!/usr/bin/env python
 import os
+import signal
 import sys
+
+# OpenBench.apps registers an atexit shutdown() that gracefully stops the PGN
+# and Artifact watcher threads -- joining them so any in-flight tar write is
+# allowed to finish. atexit only runs on a clean interpreter exit, not on a
+# bare SIGTERM, so we install a SIGTERM handler that turns the kill signal into
+# a clean sys.exit() and thereby triggers that atexit shutdown().
+#
+# signal.signal() may only be called from the main thread, and ready() (where
+# the watchers are spawned) is not guaranteed to run there. So the handler is
+# installed at the two process entry points instead, each of which IS the main
+# thread of its own process:
+#
+#     manage.py        -> the entry point for `runserver`        (here)
+#     OpenSite/wsgi.py -> the module gunicorn imports per worker (the gunicorn case)
+#
+# Whichever entry point starts the process installs the handler; the other
+# no-ops for that run (under runserver, wsgi.py is imported off the main thread
+# and skips itself). Keep this block and the handler in sync across both files.
+#
+# Ignore any further SIGTERMs so the atexit shutdown runs to completion. A
+# `pkill -TERM gunicorn` hits each worker directly AND the arbiter, which
+# then broadcasts a second SIGTERM to every worker; without this the second
+# signal would re-enter here and abort the shutdown partway through.
+
+def graceful_exit_on_sigterm(*args):
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    sys.exit(0)
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "OpenSite.settings")
+
+    signal.signal(signal.SIGTERM, graceful_exit_on_sigterm)
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
Can cause a slow shutdown in two cases:
- Lots of work in the (Artifact) Watcher
- Lots of work in the PGN Watcher

Former probably not important.
Latter can be solved by only doing discrete chunks of work at a time.
Paired with the batching solution for a nice touch.