### PR TITLE
Fix search page layout after adding info box

### DIFF
--- a/OpenBench/static/style.css
+++ b/OpenBench/static/style.css
@@ -317,12 +317,12 @@ body, html, main{
     width: 100%;
 }
 
-#content .test-list tr td:nth-of-type(7) {
+#content .test-list tr td.test-info {
     width: 100%;
     max-width: 0;
 }
 
-#content .test-list tr td:nth-of-type(7) div {
+#content .test-list tr td.test-info div {
     max-height: 5.8em;
     overflow: hidden;
     white-space: normal;
@@ -503,7 +503,7 @@ td pre {
         overflow-x: auto;
     }
 
-    #content .test-list tr td:nth-of-type(7) {
+    #content .test-list tr td.test-info {
         display: none;
     }
 }

--- a/Templates/OpenBench/Blocks/testsummary.html
+++ b/Templates/OpenBench/Blocks/testsummary.html
@@ -13,4 +13,4 @@
     {% if test|test_is_smp_odds %} <span style="color: orange; cursor: pointer" title="Thread odds">*</span> {% endif %}
 </td>
 <td class='statblock statblock-{{test|testResultColour}}'><strong>{{test|shortStatBlock|linebreaksbr}}</strong></td>
-<td><div>{{test.info}}</div></td>
+<td class="test-info"><div>{{test.info}}</div></td>

--- a/Templates/OpenBench/search.html
+++ b/Templates/OpenBench/search.html
@@ -25,6 +25,12 @@
 
     </script>
 
+    <style>
+        #content {
+            max-width: 100%;
+        }
+    </style>
+
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
- Properly target the info box cell (as search's date column shifts the index by one, so it overflowed)
- Stretch the search page to full width

<img width="1519" height="124" alt="image" src="https://github.com/user-attachments/assets/71965767-6bf7-414f-875e-367cae7b7321" />

Closes #330