### PR TITLE
Request client update before creating a machine

### DIFF
--- a/OpenBench/utils.py
+++ b/OpenBench/utils.py
@@ -265,27 +265,6 @@ def branch_is_out_of_date(test):
 
 
 
-def get_machine(machineid, user, info):
-
-    # Create a new machine if we don't have an id
-    if machineid == 'None':
-        return Machine(user=user, info=info)
-
-    # Fetch the requested machine, which hopefully exists
-    try: machine = Machine.objects.get(id=int(machineid))
-    except: return None
-
-    # Workload requests should always contain a MAC
-    if 'mac_address' not in machine.info:
-        return None
-
-    # Soft-verify by checking if the MAC addresses match
-    if machine.info['mac_address'] != info['mac_address']:
-        return None
-
-    return machine
-
-
 # Purely Helper functions for Networks views
 
 def network_disambiguate(engine, identifier):

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -636,9 +636,15 @@ def client_worker_info(request):
     except UnableToAuthenticate:
         return JsonResponse({ 'error' : 'Bad Credentials' })
 
+    # Request update before creating a machine
+    info         = json.loads(request.POST['system_info'])
+    expected_ver = OPENBENCH_CONFIG['client_version']
+
+    if info.get('client_ver') != expected_ver:
+        return JsonResponse({ 'error' : 'Bad Client Version: Expected %d' % (expected_ver)})
+
     # Create a new Machine for this session
-    info    = json.loads(request.POST['system_info'])
-    machine = OpenBench.utils.get_machine('None', user, info)
+    machine = Machine(user=user, info=info)
 
     # Save the machine's latest information and Secret Token for this session
     machine.info   = info


### PR DESCRIPTION
Also removes the outdated `get_machine` functionality, which is no longer used.

Closes #329 