### PR TITLE
Allow getting bench from a file in the repo

### DIFF
--- a/OpenBench/workloads/verify_workload.py
+++ b/OpenBench/workloads/verify_workload.py
@@ -441,13 +441,17 @@ def collect_github_info(errors, request, field):
         assert 'message' in data['commit'] and 'sha' in data
         assert private or 'sha' in data['commit']['tree']
 
+        bench_file_sha = data['sha']
+        bench_file_url = OpenBench.utils.path_join(base, f'contents/.bench?ref={bench_file_sha}')
+        bench_file_data = requests.get(bench_file_url, headers=headers).json()
+
     except: # Unable to find for whatever reason
         traceback.print_exc()
         errors.append('%s could not be found' % (branch or 'Branch'))
         return (None, None)
 
-    # Extract the bench from the web form, or from the commit message
-    if not (bench := determine_bench(request, field, data['commit']['message'])):
+    # Extract the bench from the web form, or from the repository
+    if not (bench := determine_bench(request, field, data['commit']['message'], bench_file_data)):
         errors.append('Unable to parse a Bench for %s' % (branch))
         return (None, None)
 
@@ -477,7 +481,7 @@ def requests_illegal_fork(request, field):
     # Illegal if sources do not match for Private engines
     return engine['private'] and eng_src != tar_src
 
-def determine_bench(request, field, message):
+def determine_bench(request, field, message, bench_file_data):
 
     # Use the provided bench if possible
     try: return int(request.POST['{0}_bench'.format(field)])
@@ -487,7 +491,18 @@ def determine_bench(request, field, message):
     try:
         benches = re.findall('(?:BENCH|NODES)[ :=]+([0-9,]+)', message, re.IGNORECASE)
         return int(benches[-1].replace(',', ''))
-    except: return None
+    except: pass
+
+    # If there's a bench file in the repo, use that
+    try:
+        import base64
+        base64_bench = bench_file_data["content"].strip()
+        bench = base64.b64decode(base64_bench)
+        return int(bench)
+    except: pass
+
+    return None
+
 
 def fetch_artifact_url(base, engine, headers, sha):
 


### PR DESCRIPTION
Currently benches are stored in commits which means:

* Every commit needs to include a bench number, even ones that clearly can't change the bench (e.g. typo fixes, documentation updates, etc.).

  With the bench stored in a file, the last bench is carried across by default.

* Commit messages need to be parsed to extract bench

  With the bench stored in a file, the contents can be used directly with no need to parse it.

  At least for myself, I've found this makes automation around bench easier. For example, a CI job that checks the engine's bench matches currently needs to replicate OB's parsing logic but could, with these changes, just compare directly with the contents of the file. Similarly, updating can be done by just piping into the file.

* Bench changes aren't included in diffs

  This is a small one, but I have found it helpful to be able to see,
  without referencing previous commits, if a given diff changed bench.

I've had this patched into my own instance for roughly a year now and have preferred the experience, so thought I would see if there is any appetite for getting it merged upstream.