### PR TITLE
Change Igel test params

### DIFF
--- a/Engines/Igel.json
+++ b/Engines/Igel.json
@@ -5,8 +5,8 @@
 
     "build" : {
         "path"      : "src",
-        "compilers" : ["g++"],
-        "cpuflags"  : ["POPCNT"],
+        "compilers" : ["clang++", "g++"],
+        "cpuflags"  : ["AVX2", "FMA", "POPCNT"],
         "systems"   : ["Windows", "Linux"]
     },
 
@@ -14,8 +14,8 @@
 
         "default" : {
             "base_branch"     : "master",
-            "book_name"       : "Pohl.epd",
-            "test_bounds"     : "[0.00, 3.00]",
+            "book_name"       : "UHO_Lichess_4852_v1.epd",
+            "test_bounds"     : "[0.00, 2.00]",
             "test_confidence" : "[0.05, 0.05]",
             "win_adj"         : "movecount=3 score=400",
             "draw_adj"        : "movenumber=40 movecount=8 score=10"
@@ -49,7 +49,7 @@
     "tune_presets" : {
 
         "default" : {
-            "book_name" : "Pohl.epd",
+            "book_name" : "UHO_Lichess_4852_v1.epd",
             "win_adj"   : "movecount=3 score=400",
             "draw_adj"  : "movenumber=40 movecount=8 score=10"
         }


### PR DESCRIPTION
Hi Andrew,

I would like to update a few default parameters for Igel as a part of this PR.

Also, it's been a while since Igel NPS/speed was recalibrated on your Threadripper machine used as a benchmark - I was wondering if you could do that as well (preferably with a clang++ build).

Thank you!